### PR TITLE
Convert files encoded in ITS evacuate format, to ASCII + bit 0 format.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ bin2x
 its2bin
 its2x
 its2rim
+its2ascii
 itsarc
 dis10
 magdmp

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OBJS =	pdp10-opc.o info.o word.o sblk.o pdump.o dis.o symbols.o \
 	timing.o timing_ka10.o timing_ki10.o memory.o $(WORDS)
 
 UTILS =	bin2ascii bin2x its2x its2bin its2rim itsarc magdmp magfrm dskdmp \
-	macdmp saildart macro-tapes tape-dir harscntopbm palx
+	macdmp saildart macro-tapes tape-dir harscntopbm palx its2ascii
 
 all: dis10 $(UTILS) check
 
@@ -36,6 +36,9 @@ its2bin: its2bin.o word.o $(WORDS)
 
 its2rim: its2rim.o word.o $(WORDS)
 	$(CC) $^ -o its2rim
+
+its2ascii: its2ascii.o word.o $(WORDS)
+	$(CC) $^ -o $@
 
 dskdmp: dskdmp.c $(OBJS)
 	$(CC) $^ -o $@

--- a/its2ascii.c
+++ b/its2ascii.c
@@ -1,0 +1,42 @@
+/* Copyright (C) 2019 Lars Brinkhoff <lars@nocrew.org>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <stdio.h>
+
+#include "dis.h"
+
+extern word_t get_its_word (FILE *f);
+extern word_t write_aa_word (FILE *f, word_t);
+
+int
+main (int argc, char **argv)
+{
+  word_t word;
+
+  if (argc != 1)
+    {
+      fprintf (stderr, "Usage: %s < infile > outfile\n", argv[0]);
+      exit (1);
+    }
+
+  file_36bit_format = FORMAT_ITS;
+
+  while ((word = get_its_word (stdin)) != -1)
+    {
+      write_aa_word (stdout, word);
+    }
+
+  return 0;
+}


### PR DESCRIPTION
Hello @rricharz,

This `its2ascii` program converts from the ITS format to plain ASCII. 

Unnecessary details:

As you may know, the PDP-10 is a 36-bit computer.  ASCII text is stored as five 7-bit characters aligned to the left.  This leaves one bit unused.  When converting this to a 8-bit byte file, we get five characters with the top bit zero.

In order to use the same format for binary files, the last bit in the 36-bit word is stored as the top bit in character five.