### PR TITLE
MAGFRM improvements.

### DIFF
--- a/magfrm.c
+++ b/magfrm.c
@@ -22,6 +22,26 @@ extern word_t get_its_word (FILE *f);
 extern void write_core_word (FILE *f, word_t);
 extern word_t ascii_to_sixbit (char *);
 
+word_t mthri[] =
+{
+  0777761000000, /* -17,,0 */
+  0255000000000, /* JFCL */
+  0541440000004, /* HRRI 11,4 */
+  0734740000001, /* CONSO 344,1 */
+  0254000000003, /* JRST 3 */
+  0241011777776, /* ROT -2(11) */
+  0734071000010, /* DATAI 340,@10(11) */
+  0256011000010, /* XCT 10(11) */
+  0256011000013, /* XCT 13(11) */
+  0364440000000, /* SOJA 11,0 */
+  0312000000017, /* CAME 17 */
+  0270017000000, /* ADD (17) */
+  0331740000000, /* SKIPL 17,0 */
+  0254200000015, /* JRST 4,15 */
+  0253740000003, /* AOBJN 17,3 */
+  0254000000002  /* JRST 2 */
+};
+
 static int write_reclen (FILE *f, int reclen)
 {
   /* A SIMH tape image record length is 32-bit little endian. */
@@ -138,6 +158,39 @@ write_file (FILE *f, char *name)
   write_record (f, 0, buffer);
 }
 
+static void
+write_hri (FILE *f, const char *file)
+{
+  FILE *in = fopen (file, "rb");
+  word_t word, *p;
+
+  /* The hardware read-in record starts with an SBLK loader. */
+  memcpy (buffer, mthri, sizeof mthri);
+
+  /* Look for a JRST 1 in the input file. */
+  p = buffer + sizeof mthri / sizeof (word_t);
+  for (;;)
+    {
+      word = get_its_word (in);
+      if (word == 0254000000001LL)
+        break;
+      if (word == -1)
+        exit (1);
+    }
+
+  /* Next copy the file to tape. */
+  for (;;)
+    {
+      word = get_its_word (in);
+      if (word == -1)
+        break;
+      *p++ = word;
+    }
+
+  write_record (stdout, p - buffer, buffer);
+  write_record (stdout, 0, buffer);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -159,12 +212,11 @@ main (int argc, char **argv)
 
   memset (buffer, 0, sizeof buffer);
 
-  /* The first tape record should be MAGDMP, ended by a tape mark.
-     Just a placeholder for now. */
-  write_record (stdout, 2, buffer);
-  write_record (stdout, 0, buffer);
+  /* The first tape record is for hardware read-in, ended by a tape
+     mark.  The first 16 words are an SBLK loader, next comes MAGDMP. */
+  write_hri (stdout, argv[1]);
 
-  for (i = 1; i < argc; i++)
+  for (i = 2; i < argc; i++)
     write_file (stdout, argv[i]);
 
   return 0;


### PR DESCRIPTION
Primarily, make tape bootable with hardware read-in.

This is done by putting a read-in bootstrap first on the tape, and then append SBLK blocks.