### PR TITLE
Rework generic word IO code, and add conv36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.ipak
 *.scrmbl
 *.unscrm
+conv36
 bin2ascii
 bin2x
 ipak

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ WORDS =  bin-word.o its-word.o x-word.o dta-word.o aa-word.o pt-word.o core-word
 OBJS =	pdp10-opc.o info.o word.o sblk.o pdump.o dis.o symbols.o \
 	timing.o timing_ka10.o timing_ki10.o memory.o
 
-UTILS =	bin2ascii bin2x its2x its2bin its2rim itsarc magdmp magfrm dskdmp \
+UTILS =	conv36 bin2ascii bin2x its2x its2bin its2rim itsarc magdmp magfrm dskdmp \
 	macdmp saildart macro-tapes tape-dir harscntopbm palx its2ascii \
 	tracks ipak kldcp klfedr scrmbl
 
@@ -25,6 +25,9 @@ dis10: main.o $(OBJS) dmp.o raw.o libwords.a
 
 libwords.a: word.o $(WORDS)
 	ar -crs $@ $^
+
+conv36: conv36.o libwords.a
+	$(CC) -g $^ -o $@
 
 bin2ascii: bin2ascii.o
 	$(CC) bin2ascii.o -o bin2ascii
@@ -132,6 +135,7 @@ samples/stink.-ipak- = -Wascii
 bin-word.o: bin-word.c dis.h
 bin2ascii.o: bin2ascii.c
 bin2x.o: bin2x.c
+conv36.o: dis.h
 dis.o: dis.c opcode/pdp10.h dis.h memory.h timing.h
 info.o: info.c dis.h memory.h
 its-word.o: its-word.c dis.h

--- a/aa-word.c
+++ b/aa-word.c
@@ -35,7 +35,7 @@ get_byte (FILE *f)
   return c == EOF ? 0 : c;
 }
 
-word_t
+static word_t
 get_aa_word (FILE *f)
 {
   word_t word = 0;
@@ -56,13 +56,7 @@ get_aa_word (FILE *f)
   return word;
 }
 
-void
-rewind_aa_word (FILE *f)
-{
-  rewind (f);
-}
-
-void
+static void
 write_aa_word (FILE *f, word_t word)
 {
   fputc ((word >> 29) & 0177, f);
@@ -73,8 +67,10 @@ write_aa_word (FILE *f, word_t word)
 	 ((word << 7) & 0200), f);
 }
 
-static void
-flush_aa_word (FILE *f)
-{
-  (void)f;
-}
+struct word_format aa_word_format = {
+  "ascii",
+  get_aa_word,
+  NULL,
+  write_aa_word,
+  NULL
+};

--- a/bin-word.c
+++ b/bin-word.c
@@ -26,7 +26,7 @@ get_byte (FILE *f)
   return c == EOF ? 0 : c;
 }
 
-word_t
+static word_t
 get_bin_word (FILE *f)
 {
   unsigned char byte;
@@ -67,9 +67,17 @@ get_bin_word (FILE *f)
   return word;
 }
 
-void
+static void
 rewind_bin_word (FILE *f)
 {
   there_is_some_leftover = 0;
   rewind (f);
 }
+
+struct word_format bin_word_format = {
+  "bin",
+  get_bin_word,
+  rewind_bin_word,
+  NULL,
+  NULL
+};

--- a/conv36.c
+++ b/conv36.c
@@ -1,0 +1,120 @@
+/* Copyright (C) 2013 Lars Brinkhoff <lars@nocrew.org>
+   Copyright (C) 2020 Adam Sampson <ats@offog.org>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "dis.h"
+
+static void
+usage (char **argv)
+{
+  fprintf (stderr, "Usage: %s [-W<input word format>] [-X<output word format>] [<input file>]\n\n", argv[0]);
+  usage_word_format ();
+  exit (1);
+}
+
+/* If invoked with a name like "its2bin", default to those formats. */
+static void
+default_formats (const char *argv0)
+{
+  int bad = 0;
+  const char *basename;
+  const char *two;
+  char *first;
+
+  basename = strrchr (argv0, '/');
+  if (basename == NULL)
+    basename = argv0;
+  else
+    basename++;
+
+  two = strchr (basename, '2');
+  if (two == NULL)
+    return;
+
+  first = strndup (basename, two - basename);
+  if (first == NULL)
+    {
+      fprintf (stderr, "out of memory\n");
+      exit (1);
+    }
+  if (parse_input_word_format (first))
+    bad = 1;
+  if (parse_output_word_format (two + 1))
+    bad = 1;
+  free (first);
+
+  if (bad)
+    {
+      fprintf (stderr, "%s: unrecognised word format in executable name\n", argv0);
+      exit (1);
+    }
+}
+
+int
+main (int argc, char **argv)
+{
+  FILE *file;
+  int opt;
+  word_t word;
+
+  default_formats (argv[0]);
+
+  while ((opt = getopt (argc, argv, "W:X:")) != -1)
+    {
+      switch (opt)
+        {
+        case 'W':
+          if (parse_input_word_format (optarg))
+            usage (argv);
+          break;
+        case 'X':
+          if (parse_output_word_format (optarg))
+            usage (argv);
+          break;
+        default:
+          usage (argv);
+        }
+    }
+
+  if (optind == argc)
+    file = stdin;
+  else if (optind == argc - 1)
+    {
+      file = fopen (argv[optind], "rb");
+      if (file == NULL)
+        {
+          fprintf (stderr, "%s: Error opening %s: %s\n",
+                   argv[0], argv[optind], strerror (errno));
+          return 1;
+        }
+    }
+  else
+    usage (argv);
+
+  while ((word = get_word (file)) != -1)
+    write_word (stdout, word);
+  flush_word (stdout);
+
+  if (file != stdin)
+    fclose (file);
+
+  return 0;
+}

--- a/core-word.c
+++ b/core-word.c
@@ -51,8 +51,10 @@ write_core_word (FILE *f, word_t word)
   fputc ( word        & 0x0F, f);
 }
 
-void
-rewind_core_word (FILE *f)
-{
-  rewind (f);
-}
+struct word_format core_word_format = {
+  "core",
+  get_core_word,
+  NULL,
+  write_core_word,
+  NULL
+};

--- a/dis.h
+++ b/dis.h
@@ -29,8 +29,13 @@ typedef long long word_t;
 
 #define JRST_1 ((word_t)(0254000000001LL))
 
-enum { FORMAT_BIN, FORMAT_ITS, FORMAT_X, FORMAT_DTA, FORMAT_AA, FORMAT_PT,
-       FORMAT_CORE, FORMAT_TAPE, FORMAT_TAPE7 };
+struct word_format {
+  const char *name;
+  word_t (*get_word) (FILE *);
+  void (*rewind_word) (FILE *);		/* NULL means just rewind (f) */
+  void (*write_word) (FILE *, word_t);
+  void (*flush_word) (FILE *);		/* NULL means do nothing */
+};
 
 enum { SYMBOLS_NONE, SYMBOLS_DDT, SYMBOLS_ALL };
 
@@ -40,25 +45,33 @@ struct FILE;
 struct pdp10_file;
 struct pdp10_memory;
 
-extern int	file_36bit_format;
+extern struct word_format *input_word_format;
+extern struct word_format *output_word_format;
+extern struct word_format aa_word_format;
+extern struct word_format bin_word_format;
+extern struct word_format core_word_format;
+extern struct word_format dta_word_format;
+extern struct word_format its_word_format;
+extern struct word_format pt_word_format;
+extern struct word_format tape_word_format;
+extern struct word_format tape7_word_format;
+extern struct word_format x_word_format;
+
 extern void     usage_word_format (void);
-extern int      parse_word_format (const char *string);
+extern int      parse_input_word_format (const char *);
+extern int      parse_output_word_format (const char *);
 extern word_t	get_word (FILE *f);
 extern word_t	get_checksummed_word (FILE *f);
 extern void	reset_checksum (word_t);
 extern void	check_checksum (word_t);
 extern void	rewind_word (FILE *f);
-extern void	write_its_word (FILE *, word_t);
-extern void	flush_its_word (FILE *);
-extern word_t	get_aa_word (FILE *);
-extern word_t	get_pt_word (FILE *);
-extern void	rewind_aa_word (FILE *);
-extern word_t	get_tape_word (FILE *);
-extern void	rewind_tape_word (FILE *);
+extern void	write_word (FILE *, word_t);
+extern void	flush_word (FILE *);
 extern int      get_7track_record (FILE *f, word_t **buffer);
 extern int      get_9track_record (FILE *f, word_t **buffer);
 extern void     write_7track_record (FILE *f, word_t *buffer, int);
 extern void     write_9track_record (FILE *f, word_t *buffer, int);
+extern word_t	get_core_word (FILE *f);
 extern void	write_core_word (FILE *f, word_t word);
 extern void	dis_pdump (FILE *f, int cpu_model);
 extern void	dis_sblk (FILE *f, int cpu_model);

--- a/dta-word.c
+++ b/dta-word.c
@@ -33,7 +33,7 @@ get_half (FILE *f)
 	  + (get_byte (f) << 24));
 }
 
-word_t
+static word_t
 get_dta_word (FILE *f)
 {
   word_t word, h1, h2;
@@ -52,8 +52,10 @@ get_dta_word (FILE *f)
   return word;
 }
 
-void
-rewind_dta_word (FILE *f)
-{
-  rewind (f);
-}
+struct word_format dta_word_format = {
+  "dta",
+  get_dta_word,
+  NULL,
+  NULL,
+  NULL
+};

--- a/harscntopbm.c
+++ b/harscntopbm.c
@@ -199,7 +199,7 @@ main (int argc, char **argv)
       switch (opt)
 	{
 	case 'W':
-	  if (parse_word_format (optarg))
+	  if (parse_input_word_format (optarg))
 	    usage (argv);
 	  break;
 	default:

--- a/ipak.c
+++ b/ipak.c
@@ -32,12 +32,10 @@ static word_t buffer[256 * 1024];
 
 static void usage (const char *x)
 {
-  fprintf (stderr, "Usage: %s -t|-x[e] <file>\n", x);
+  fprintf (stderr, "Usage: %s -t|-x[e] [-W<input word format>] [-X<output word format>] <file>\n", x);
+  usage_word_format ();
   exit (1);
 }
-
-static void (*write_word) (FILE *, word_t);
-static void (*flush_word) (FILE *);
 
 static void
 massage (char *filename)
@@ -118,9 +116,7 @@ main (int argc, char **argv)
   int opt;
   int i;
 
-  file_36bit_format = FORMAT_ITS;
-
-  while ((opt = getopt (argc, argv, "etxW:")) != -1)
+  while ((opt = getopt (argc, argv, "etxW:X:")) != -1)
     {
       switch (opt)
 	{
@@ -134,7 +130,11 @@ main (int argc, char **argv)
 	  extract = 1;
 	  break;
 	case 'W':
-	  if (parse_word_format (optarg))
+	  if (parse_input_word_format (optarg))
+	    usage (argv[0]);
+	  break;
+	case 'X':
+	  if (parse_output_word_format (optarg))
 	    usage (argv[0]);
 	  break;
 	default:
@@ -146,10 +146,6 @@ main (int argc, char **argv)
     usage (argv[0]);
 
   f = fopen (argv[optind], "rb");
-
-  /* Output format. */
-  write_word = write_its_word;
-  flush_word = flush_its_word;
 
   p = buffer;
   while ((word = get_word (f)) != -1)

--- a/its-word.c
+++ b/its-word.c
@@ -33,7 +33,7 @@ insert (word_t word, unsigned char byte, int *bits)
   return (word << 7) | byte;
 }
 
-word_t
+static word_t
 get_its_word (FILE *f)
 {
   unsigned char byte;
@@ -151,7 +151,7 @@ get_its_word (FILE *f)
   return word;
 }
 
-void
+static void
 rewind_its_word (FILE *f)
 {
   there_is_some_leftover = 0;
@@ -167,7 +167,7 @@ fputc2 (int c1, int c2, FILE *f)
 
 static int previous_octet = -1;
 
-void
+static void
 flush_its_word (FILE *f)
 {
   if (previous_octet == 015)
@@ -249,7 +249,7 @@ ascii_word (FILE *f, word_t word)
     }
 }
 
-void
+static void
 write_its_word (FILE *f, word_t word)
 {
   if (word & 1)
@@ -257,3 +257,11 @@ write_its_word (FILE *f, word_t word)
   else
     ascii_word (f, word);
 }
+
+struct word_format its_word_format = {
+  "its",
+  get_its_word,
+  rewind_its_word,
+  write_its_word,
+  flush_its_word
+};

--- a/its2ascii.c
+++ b/its2ascii.c
@@ -17,13 +17,13 @@
 
 #include "dis.h"
 
-extern word_t get_its_word (FILE *f);
-extern word_t write_aa_word (FILE *f, word_t);
-
 int
 main (int argc, char **argv)
 {
   word_t word;
+
+  input_word_format = &its_word_format;
+  output_word_format = &aa_word_format;
 
   if (argc != 1)
     {
@@ -31,12 +31,11 @@ main (int argc, char **argv)
       exit (1);
     }
 
-  file_36bit_format = FORMAT_ITS;
-
-  while ((word = get_its_word (stdin)) != -1)
+  while ((word = get_word (stdin)) != -1)
     {
-      write_aa_word (stdout, word);
+      write_word (stdout, word);
     }
 
+  flush_word (stdout);
   return 0;
 }

--- a/its2bin.c
+++ b/its2bin.c
@@ -17,13 +17,13 @@
 
 #include "dis.h"
 
-extern word_t get_its_word (FILE *f);
-
 int
 main (int argc, char **argv)
 {
   word_t word1, word2;
   FILE *f;
+
+  input_word_format = &its_word_format;
 
   if (argc != 2)
     {
@@ -33,14 +33,14 @@ main (int argc, char **argv)
 
   f = fopen (argv[1], "rb");
 
-  while ((word1 = get_its_word (f)) != -1)
+  while ((word1 = get_word (f)) != -1)
     {
       putchar ((word1 >> 28) & 0xff);
       putchar ((word1 >> 20) & 0xff);
       putchar ((word1 >> 12) & 0xff);
       putchar ((word1 >>  4) & 0xff);
 
-      word2 = get_its_word (f);
+      word2 = get_word (f);
       if (word2 == -1)
 	{
 	  putchar ((word1 << 4) & 0xf0);

--- a/its2rim.c
+++ b/its2rim.c
@@ -17,13 +17,13 @@
 
 #include "dis.h"
 
-extern word_t get_its_word (FILE *f);
-
 int
 main (int argc, char **argv)
 {
   word_t word;
   FILE *f;
+
+  input_word_format = &its_word_format;
 
   if (argc != 2)
     {
@@ -32,9 +32,8 @@ main (int argc, char **argv)
     }
 
   f = fopen (argv[1], "rb");
-  file_36bit_format = FORMAT_ITS;
 
-  while ((word = get_its_word (f)) != -1)
+  while ((word = get_word (f)) != -1)
     {
       int i;
       for (i = 0; i < 6; i++)

--- a/its2x.c
+++ b/its2x.c
@@ -17,13 +17,13 @@
 
 #include "dis.h"
 
-extern word_t get_its_word (FILE *f);
-
 int
 main (int argc, char **argv)
 {
   word_t word;
   FILE *f;
+
+  input_word_format = &its_word_format;
 
   if (argc != 2)
     {
@@ -32,9 +32,8 @@ main (int argc, char **argv)
     }
 
   f = fopen (argv[1], "rb");
-  file_36bit_format = FORMAT_ITS;
 
-  while ((word = get_its_word (f)) != -1)
+  while ((word = get_word (f)) != -1)
     {
       putchar ((word >> 32) & 0x0f);
       putchar ((word >> 24) & 0xff);

--- a/itsarc.c
+++ b/itsarc.c
@@ -28,8 +28,6 @@
 
 static int old = 0;
 
-extern word_t get_its_word (FILE *f);
-
 /* Just allocate a full moby to hold the file. */
 static word_t buffer[256 * 1024];
 
@@ -38,9 +36,6 @@ static void usage (const char *x)
   fprintf (stderr, "Usage: %s -x|-t <file>\n", x);
   exit (1);
 }
-
-static void (*write_word) (FILE *, word_t);
-static void (*flush_word) (FILE *);
 
 static void
 massage (char *filename)
@@ -204,6 +199,9 @@ main (int argc, char **argv)
   word_t *p;
   FILE *f;
 
+  input_word_format = &its_word_format;
+  output_word_format = &its_word_format;
+
   if (argc != 3)
     usage (argv[0]);
 
@@ -224,11 +222,6 @@ main (int argc, char **argv)
     }
 
   f = fopen (argv[2], "rb");
-  file_36bit_format = FORMAT_ITS;
-
-  /* Output format. */
-  write_word = write_its_word;
-  flush_word = flush_its_word;
 
   p = buffer;
   while ((word = get_word (f)) != -1)

--- a/kldcp.c
+++ b/kldcp.c
@@ -251,7 +251,7 @@ main (int argc, char **argv)
 {
   FILE *f;
 
-  file_36bit_format = FORMAT_ITS;
+  input_word_format = &its_word_format;
 
   if (argc != 4)
     usage (argv[0]);

--- a/klfedr.c
+++ b/klfedr.c
@@ -40,14 +40,14 @@ write_empty_dir (FILE *f)
      words, or really, 16 16-bit words. */
   for (i = 0; i < 128; i += 8)
     {
-      write_its_word (f, 0777776777776LL);  /* I see no file here. */
-      write_its_word (f, 0777776000000LL);
-      write_its_word (f, 0);
-      write_its_word (f, 0);
-      write_its_word (f, 0);
-      write_its_word (f, 0);
-      write_its_word (f, 0);
-      write_its_word (f, 0);
+      write_word (f, 0777776777776LL);  /* I see no file here. */
+      write_word (f, 0777776000000LL);
+      write_word (f, 0);
+      write_word (f, 0);
+      write_word (f, 0);
+      write_word (f, 0);
+      write_word (f, 0);
+      write_word (f, 0);
     }
 }
 
@@ -59,7 +59,8 @@ main (int argc, char **argv)
   (void)argc;
   (void)argv;
 
-  file_36bit_format = FORMAT_ITS;
+  input_word_format = &its_word_format;
+  output_word_format = &its_word_format;
 
   /* The KLDCP direcory is 64 sectors. */
   for (i = 0; i < 64; i++)
@@ -67,5 +68,6 @@ main (int argc, char **argv)
       write_empty_dir (stdout);
     }
 
+  flush_word (stdout);
   return 0;
 }

--- a/macdmp.c
+++ b/macdmp.c
@@ -52,15 +52,13 @@ get_block (int block)
   return &image[block * 128];
 }
 
-extern word_t get_dta_word (FILE *f);
-
 static int read_block (FILE *f, word_t *buffer)
 {
   int i;
 
   for (i = 0; i < BLOCK_WORDS; i++)
     {
-      buffer[i] = get_dta_word (f);
+      buffer[i] = get_word (f);
       if (buffer[i] == -1)
 	return -1;
     }
@@ -163,26 +161,6 @@ show_blocks (void)
       printf ("%s blocks: %d\n", blocktype[i], blocks[i]);
       empty = 0;
     }
-}
-
-static void (*write_word) (FILE *, word_t);
-static void (*flush_word) (FILE *);
-
-static void
-write_aa_word (FILE *f, word_t word)
-{
-  fputc ((word >> 29) & 0177, f);
-  fputc ((word >> 22) & 0177, f);
-  fputc ((word >> 15) & 0177, f);
-  fputc ((word >>  8) & 0177, f);
-  fputc (((word >> 1) & 0177) +
-	 ((word << 7) & 0200), f);
-}
-
-static void
-flush_aa_word (FILE *f)
-{
-  (void)f;
 }
 
 static void
@@ -305,7 +283,9 @@ main (int argc, char **argv)
   FILE *f;
   int i;
 
-  file_36bit_format = FORMAT_DTA;
+  input_word_format = &dta_word_format;
+  output_word_format = &its_word_format;
+  verbose = 1;
 
   if (argc != 3)
     usage (argv[0]);
@@ -325,12 +305,6 @@ main (int argc, char **argv)
       usage (argv[0]);
       break;
     }
-
-  verbose = 1;
-
-  /* Output format. */
-  write_word = write_its_word;
-  flush_word = flush_its_word;
 
   f = fopen (argv[2], "rb");
   if (f == NULL)

--- a/magfrm.c
+++ b/magfrm.c
@@ -18,8 +18,6 @@
 
 #include "dis.h"
 
-extern word_t get_its_word (FILE *f);
-
 word_t mthri[] =
 {
   0777761000000, /* -17,,0 */
@@ -95,7 +93,7 @@ write_file (FILE *f, char *name)
   /* Then file data in 1024 word records, terminated by a tape mark. */
   for (;;)
     {
-      word_t word = get_its_word (in);
+      word_t word = get_word (in);
 
       if (word != -1)
 	{
@@ -134,7 +132,7 @@ write_hri (FILE *f, const char *file)
   p = buffer + sizeof mthri / sizeof (word_t);
   for (;;)
     {
-      word = get_its_word (in);
+      word = get_word (in);
       if (word == 0254000000001LL)
         break;
       if (word == -1)
@@ -144,7 +142,7 @@ write_hri (FILE *f, const char *file)
   /* Next copy the file to tape. */
   for (;;)
     {
-      word = get_its_word (in);
+      word = get_word (in);
       if (word == -1)
         break;
       *p++ = word;
@@ -173,6 +171,8 @@ main (int argc, char **argv)
   FILE *f;
   int i = 1;
   int eof = 0;
+
+  input_word_format = &its_word_format;
 
   /* Default to 9-track tape. */
   nine_tracks ();

--- a/main.c
+++ b/main.c
@@ -62,7 +62,7 @@ main (int argc, char **argv)
 	    usage (argv);
 	  break;
 	case 'W':
-	  if (parse_word_format (optarg))
+	  if (parse_input_word_format (optarg))
 	    usage (argv);
 	  break;
 	case 'D':

--- a/palx.c
+++ b/palx.c
@@ -117,14 +117,14 @@ main (int argc, char **argv)
 {
   int opt;
 
-  file_36bit_format = FORMAT_ITS;
+  input_word_format = &its_word_format;
 
   while ((opt = getopt (argc, argv, "AIW:")) != -1)
     {
       switch (opt)
 	{
 	case 'W':
-	  if (parse_word_format (optarg))
+	  if (parse_input_word_format (optarg))
 	    usage (argv[0]);
 	  break;
 	case 'A':

--- a/pt-word.c
+++ b/pt-word.c
@@ -30,7 +30,7 @@ get_byte (FILE *f)
   return c == EOF ? 0 : c;
 }
 
-word_t
+static word_t
 get_pt_word (FILE *f)
 {
   int i;
@@ -53,7 +53,7 @@ get_pt_word (FILE *f)
   return word;
 }
 
-void
+static void
 write_pt_word (FILE *f, word_t word)
 {
   fputc (((word >> 30) & 0x3F) | 0x80, f);
@@ -64,8 +64,10 @@ write_pt_word (FILE *f, word_t word)
   fputc (( word        & 0x3F) | 0x80, f);
 }
 
-void
-rewind_pt_word (FILE *f)
-{
-  rewind (f);
-}
+struct word_format pt_word_format = {
+  "pt",
+  get_pt_word,
+  NULL,
+  write_pt_word,
+  NULL
+};

--- a/saildart.c
+++ b/saildart.c
@@ -31,7 +31,7 @@ void convert (char *line)
       x += (*line++ - '0');
     }
 
-  write_its_word (stdout, x);
+  write_word (stdout, x);
 }
 
 int main (void)
@@ -57,6 +57,7 @@ int main (void)
 	  convert (line);
 	}
     }
-  
+
+  flush_word (stdout);
   return 0;
 }

--- a/scrmbl.c
+++ b/scrmbl.c
@@ -216,9 +216,8 @@ scramble (int decrypt, word_t password, const word_t *input, word_t *output, int
 static void
 usage (char **argv)
 {
-  fprintf (stderr, "Usage: %s [-d] [-v] [-W<word format>] <password> <input file> <output file>\n\n", argv[0]);
+  fprintf (stderr, "Usage: %s [-d] [-v] [-W<input word format>] [-X<output word format>] <password> <input file> <output file>\n\n", argv[0]);
   usage_word_format ();
-  fprintf (stderr, "Output is always in its word format.\n"); /* FIXME */
   exit (1);
 }
 
@@ -236,7 +235,7 @@ main (int argc, char **argv)
   word_t password;
   word_t word;
 
-  while ((opt = getopt (argc, argv, "dvW:")) != -1)
+  while ((opt = getopt (argc, argv, "dvW:X:")) != -1)
     {
       switch (opt)
         {
@@ -247,7 +246,11 @@ main (int argc, char **argv)
           verbose = 1;
           break;
         case 'W':
-          if (parse_word_format (optarg))
+          if (parse_input_word_format (optarg))
+            usage (argv);
+          break;
+        case 'X':
+          if (parse_output_word_format (optarg))
             usage (argv);
           break;
         default:
@@ -297,8 +300,9 @@ main (int argc, char **argv)
   file = fopen (argv[optind + 2], "wb");
   for (i = 0; i < input_count; i++)
     {
-      write_its_word (file, output[i]);
+      write_word (file, output[i]);
     }
+  flush_word (file);
   fclose (file);
 
   free (input);

--- a/tape-word.c
+++ b/tape-word.c
@@ -17,8 +17,6 @@
 
 #include "dis.h"
 
-extern word_t get_core_word (FILE *f);
-
 static int
 get_byte (FILE *f)
 {
@@ -211,7 +209,7 @@ int n, words;
 int end_of_file = 1;
 int end_of_tape = 0;
 
-word_t
+static word_t
 get_tape_word (FILE *f)
 {
   word_t word;
@@ -221,14 +219,14 @@ get_tape_word (FILE *f)
 
   if (buffer == NULL)
     {
-      if (file_36bit_format == FORMAT_TAPE)
+      if (input_word_format == &tape_word_format)
 	words = get_9track_record (f, &buffer);
       else
 	words = get_7track_record (f, &buffer);
       if (words == 0)
 	{
 	  end_of_file = 1;
-	  if (file_36bit_format == FORMAT_TAPE)
+	  if (input_word_format == &tape_word_format)
 	    words = get_9track_record (f, &buffer);
 	  else
 	    words = get_7track_record (f, &buffer);
@@ -260,7 +258,7 @@ get_tape_word (FILE *f)
   return word;
 }
 
-void
+static void
 rewind_tape_word (FILE *f)
 {
   if (buffer != NULL)
@@ -270,3 +268,19 @@ rewind_tape_word (FILE *f)
   buffer = NULL;
   rewind (f);
 }
+
+struct word_format tape_word_format = {
+  "tape",
+  get_tape_word,
+  rewind_tape_word,
+  NULL,
+  NULL
+};
+
+struct word_format tape7_word_format = {
+  "tape7",
+  get_tape_word,
+  rewind_tape_word,
+  NULL,
+  NULL
+};

--- a/test/test_write.c
+++ b/test/test_write.c
@@ -24,9 +24,9 @@ int main (void)
     {
       word_t word = rand36 ();
       fprintf (stderr, "%012llo\n", word);
-      write_its_word (stdout, word);
+      write_word (stdout, word);
     }
 
-  flush_its_word (stdout);
+  flush_word (stdout);
   return 0;
 }

--- a/x-word.c
+++ b/x-word.c
@@ -24,7 +24,7 @@ get_byte (FILE *f)
   return c == EOF ? 0 : c;
 }
 
-word_t
+static word_t
 get_x_word (FILE *f)
 {
   word_t word;
@@ -49,8 +49,10 @@ get_x_word (FILE *f)
   return word;
 }
 
-void
-rewind_x_word (FILE *f)
-{
-  rewind (f);
-}
+struct word_format x_word_format = {
+  "x",
+  get_x_word,
+  NULL,
+  NULL,
+  NULL
+};


### PR DESCRIPTION
Each -word.c file now defines one (or more) structures of function pointers for the formats it supports. Both reading and writing are supported.

ipak and scrambl now have an -X option to choose the output word format, which works just like -W.

conv36 (any ideas for a better name?) can convert between any of the input and output formats supported by the word library. It looks at argv[0] to decide the default formats, so you can symlink it to something like "bin2its" and it'll do the right thing when invoked that way.

It can't quite replace the existing its2bin etc., because the word library doesn't have output functions for all the formats - but that should just be a case of converting the existing code...