### PR TITLE
Word format for CADR files stored on ITS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 CFLAGS = -g -W -Wall
 
-WORDS =  bin-word.o its-word.o x-word.o dta-word.o aa-word.o pt-word.o core-word.o tape-word.o
+WORDS =  bin-word.o its-word.o x-word.o dta-word.o aa-word.o pt-word.o core-word.o tape-word.o cadr-word.o
 
 OBJS =	pdp10-opc.o info.o word.o sblk.o pdump.o dis.o symbols.o \
 	timing.o timing_ka10.o timing_ki10.o memory.o weenix.o

--- a/cadr-word.c
+++ b/cadr-word.c
@@ -1,0 +1,41 @@
+/* Copyright (C) 2020 Lars Brinkhoff <lars@nocrew.org>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <stdio.h>
+#include "dis.h"
+
+/* Data files for CADR Lisp machines were apparently stored as 32 bits
+   left aligned in a 36-bit word.  The 32-bit word is in PDP-11 endian
+   format, i.e. 16-bit words are little endian but the most
+   significant 16-bit word comes before the least significant.  Maybe
+   this is a legacy from the CONS machine which was attached to the AI
+   lab PDP-10 through Unibus. */
+
+static void
+write_cadr_word (FILE *f, word_t word)
+{
+  fputc ((word >> 20) & 0377, f);
+  fputc ((word >> 28) & 0377, f);
+  fputc ((word >>  4) & 0377, f);
+  fputc ((word >> 12) & 0377, f);
+}
+
+struct word_format cadr_word_format = {
+  "cadr",
+  NULL,
+  NULL,
+  write_cadr_word,
+  NULL
+};

--- a/dis.h
+++ b/dis.h
@@ -49,6 +49,7 @@ extern struct word_format *input_word_format;
 extern struct word_format *output_word_format;
 extern struct word_format aa_word_format;
 extern struct word_format bin_word_format;
+extern struct word_format cadr_word_format;
 extern struct word_format core_word_format;
 extern struct word_format dta_word_format;
 extern struct word_format its_word_format;

--- a/word.c
+++ b/word.c
@@ -24,6 +24,7 @@ struct word_format *output_word_format = &its_word_format;
 static struct word_format *word_formats[] = {
   &aa_word_format,
   &bin_word_format,
+  &cadr_word_format,
   &core_word_format,
   &dta_word_format,
   &its_word_format,


### PR DESCRIPTION
32-bit PDP-11 endian words stored left aligned.

CC @ams, use conv36 -Xcadr to convert ITS files.