### PR TITLE
Add prototype for squoze_to_ascii

### DIFF
--- a/dis.h
+++ b/dis.h
@@ -95,6 +95,7 @@ extern void	disassemble_word (struct pdp10_memory *memory, word_t word,
 				  int address, int cpu_model);
 extern word_t   ascii_to_sixbit (char *ascii);
 extern void	sixbit_to_ascii (word_t sixbit, char *ascii);
+extern void	squoze_to_ascii (word_t squoze, char *ascii);
 extern void	print_date (FILE *, word_t t);
 extern void	print_time (FILE *, word_t t);
 extern void	print_datime (FILE *, word_t t);


### PR DESCRIPTION
This isn't normally used, but it's required if you enable the squoze-printing code in dis.c.