### PR TITLE
Support for reading Muddle fast save files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 
 CFLAGS = -g -W -Wall
 
-FILES =  sblk-file.o pdump-file.o dmp-file.o raw-file.o shr-file.o
+FILES =  sblk-file.o pdump-file.o dmp-file.o raw-file.o shr-file.o \
+	 mdl-file.o
 
 WORDS =  bin-word.o its-word.o x-word.o dta-word.o aa-word.o pt-word.o core-word.o tape-word.o cadr-word.o
 

--- a/dis.h
+++ b/dis.h
@@ -55,6 +55,7 @@ enum { START_FILE = 1LL << 36, START_RECORD = 1LL << 37 };
 
 extern struct file_format *input_file_format;
 extern struct file_format dmp_file_format;
+extern struct file_format mdl_file_format;
 extern struct file_format pdump_file_format;
 extern struct file_format raw_file_format;
 extern struct file_format sblk_file_format;

--- a/file.c
+++ b/file.c
@@ -23,6 +23,7 @@ struct file_format *input_file_format = NULL;
 
 static struct file_format *file_formats[] = {
   &dmp_file_format,
+  &mdl_file_format,
   &pdump_file_format,
   &raw_file_format,
   &sblk_file_format,

--- a/info.c
+++ b/info.c
@@ -334,7 +334,6 @@ dmp_info (struct pdp10_memory *memory, int cpu_model)
   p = jbsym & 0777777;
   if (jbsym != -1 && p != 0 && get_word_at (memory, p) != -1)
     {
-      char str[7];
       int i;
       int length = -((jbsym >> 18) | ((-1) & ~0777777));
 
@@ -342,19 +341,9 @@ dmp_info (struct pdp10_memory *memory, int cpu_model)
 
       for (i = 0; i < length / 2; i++)
 	{
-	  word_t x = get_word_at (memory, p++);
-	  squoze_to_ascii (x, str);
-	  printf ("    Symbol %s = ", str);
-	  printf ("%llo   (", get_word_at (memory, p++));
-	  if (x & SYHKL)
-	    printf (" halfkilled");
-	  if (x & SYKIL)
-	    printf (" killed");
-	  if (x & SYLCL)
-	    printf (" local");
-	  if (x & SYGBL)
-	    printf (" global");
-	  printf (")\n");
+	  word_t word1 = get_word_at (memory, p++);
+	  word_t word2 = get_word_at (memory, p++);
+	  print_symbol (word1, word2);
 	}
     }
 }

--- a/mdl-file.c
+++ b/mdl-file.c
@@ -1,0 +1,225 @@
+/* Copyright (C) 2020 Adam Sampson <ats@offog.org>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dis.h"
+#include "memory.h"
+#include "symbols.h"
+
+/* Muddle's page map uses the ITS page size, even on TOPS-20. */
+#define MDL_PAGESIZE ITS_PAGESIZE
+
+static void
+word_to_ascii7 (word_t w, char *string)
+{
+  string[0] = (w >> 29) & 0177;
+  string[1] = (w >> 22) & 0177;
+  string[2] = (w >> 15) & 0177;
+  string[3] = (w >>  8) & 0177;
+  string[4] = (w >>  1) & 0177;
+  string[5] = 0;
+}
+
+static void
+strip_spaces (char *string)
+{
+  char *p = string + strlen (string) - 1;
+
+  while (p >= string && *p == ' ')
+    *p-- = 0;
+}
+
+static void
+add_global (const char *name, word_t value)
+{
+  printf ("    Symbol %-6s = %llo\n", name, value);
+
+  add_symbol (name, value, SYMBOL_GLOBAL);
+}
+
+/* Add a subset of the symbols from a given version of the Muddle
+   interpreter. Some of these are necessary in order to restore the
+   page map; others just help to make RSUBR code more readable. */
+static void
+define_mdl_symbols (const char *version)
+{
+  /* These are the same in all versions. */
+  add_global ("a", 01);
+  add_global ("b", 02);
+  add_global ("c", 03);
+  add_global ("d", 04);
+  add_global ("e", 05);
+  add_global ("pvp", 06);
+  add_global ("tvp", 07);
+  add_global ("sp", 010);
+  add_global ("ab", 011);
+  add_global ("tb", 012);
+  add_global ("tp", 013);
+  add_global ("frm", 014);
+  add_global ("m", 015);
+  add_global ("r", 016);
+  add_global ("p", 017);
+  add_global ("hibot", 0700000);
+
+  /* XXX Add helpers used by RSUBR code: FINIS, MPOPJ... */
+  switch (atoi (version))
+    {
+    case 54:
+      /* TS MUD54 from MIT */
+      add_global ("purtop", 0123);
+      add_global ("pmapb", 0126);
+      add_global ("globsp", 01364);
+      add_global ("glotop", 01372);
+      break;
+
+    case 104:
+      /* mdl104.exe from UChicago/LCM+L */
+      add_global ("purtop", 0163);
+      add_global ("pmapb", 0166);
+      add_global ("globsp", 01474);
+      add_global ("glotop", 01502);
+      break;
+
+    case 105:
+      /* mdl105.exe from Panda and LCM+L */
+      add_global ("purtop", 0165);
+      add_global ("pmapb", 0170);
+      add_global ("globsp", 01674);
+      add_global ("glotop", 01666);
+      break;
+
+    case 56:
+      /* TS MUD56 built in ITS repo */
+      add_global ("purtop", 0167);
+      add_global ("pmapb", 0175);
+      add_global ("globsp", 01566);
+      add_global ("glotop", 01574);
+      break;
+
+    case 106:
+      /* mdl106.exe from LCM+L */
+      add_global ("purtop", 0217);
+      add_global ("pmapb", 0222);
+      add_global ("globsp", 01677);
+      add_global ("glotop", 01705);
+      break;
+
+    default:
+      fprintf (stderr, "Unsupported Muddle version\n");
+      exit (1);
+    }
+}
+
+static void
+load_to_memory (FILE *f, struct pdp10_memory *memory,
+		int address, int length, const char *description)
+{
+  word_t *data;
+  int i;
+
+  data = malloc (length * sizeof *data);
+  if (data == NULL)
+    {
+      fprintf (stderr, "Out of memory\n");
+      exit (1);
+    }
+
+  for (i = 0; i < length; i++)
+    data[i] = get_word (f);
+
+  if (data[length - 1] == -1)
+    {
+      fprintf (stderr, "End of file during %s\n", description);
+      exit (1);
+    }
+
+  add_memory (memory, address, length, data);
+}
+
+static void
+read_mdl (FILE *f, struct pdp10_memory *memory, int cpu_model)
+{
+  (void) cpu_model; /* Not used */
+
+  word_t word;
+  char version[6];
+  word_t partop_v, purtop_v, hibot, pmapb;
+  int i;
+
+  printf ("Muddle save format\n\n");
+
+  word_to_ascii7 (get_word (f), version);
+  strip_spaces (version);
+  printf ("Muddle version: \"%s\"\n\n", version);
+
+  printf ("Interpreter symbols:\n");
+  define_mdl_symbols (version);
+
+  word = get_word (f);
+  printf ("\nValue of p.top  = %llo\n", word);
+
+  word = get_word (f);
+  if (word != 0)
+    {
+      /* This would be VECTOP in the old format. */
+      fprintf (stderr, "Muddle slow save format not supported\n");
+      exit (1);
+    }
+  printf ("Fast save format\n");
+
+  word = get_word (f);
+  printf ("Value of vectop = %llo\n", word);
+
+  partop_v = get_word (f);
+  printf ("Value of partop = %llo\n", partop_v);
+
+  /* Impure memory, from location 5 to partop. */
+  load_to_memory (f, memory, 5, partop_v - 5, "impure memory");
+
+  purtop_v = get_word_at (memory, get_symbol_value ("purtop"));
+  hibot = get_symbol_value ("hibot");
+  pmapb = get_symbol_value ("pmapb");
+
+  /* Pure memory in the page map. Only pages that are marked in the
+     page map as purified are written out. The page map has two bits
+     per page. */
+  printf ("\nPage map:\n");
+  for (i = purtop_v / MDL_PAGESIZE; i < (hibot / MDL_PAGESIZE); i++)
+    {
+      word_t entry, mask;
+      int purified;
+
+      entry = get_word_at (memory, pmapb + (i / 16));
+      mask = (1ll << 35) >> ((2 * (i % 16)) + 1);
+      purified = (entry & mask) != 0;
+      printf ("Page %03o: %s\n", i, purified ? "pure" : "not pure");
+
+      if (purified)
+	{
+	  load_to_memory (f, memory, i * MDL_PAGESIZE, MDL_PAGESIZE,
+			  "pure pages");
+	}
+    }
+
+  printf ("\n");
+}
+
+struct file_format mdl_file_format = {
+  "mdl",
+  read_mdl
+};

--- a/symbols.c
+++ b/symbols.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2018 Lars Brinkhoff <lars@nocrew.org>
-   Copyright (C) 2018, 2019 Adam Sampson <ats@offog.org>
+/* Copyright (C) 2018, 2020 Lars Brinkhoff <lars@nocrew.org>
+   Copyright (C) 2018, 2019, 2020 Adam Sampson <ats@offog.org>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -290,4 +290,34 @@ get_symbol_by_value (word_t value, int hint)
     }
 
   return first;
+}
+
+const struct symbol *
+get_symbol_by_name (const char *name)
+{
+  struct symbol key = { name, 0, -1, 0 };
+  const struct symbol *first;
+
+  sort_by (SORT_NAME);
+  first = bsearch (&key, symbols, num_symbols, sizeof *symbols,
+		   compare_name_search);
+
+  if (first == NULL)
+    return NULL;
+
+  /* Wind the pointer back to find the first symbol that matches. */
+  while (first > symbols && strcmp ((first - 1)->name, name) == 0)
+    first--;
+
+  return first;
+}
+
+word_t
+get_symbol_value (const char *name)
+{
+  const struct symbol *symbol = get_symbol_by_name (name);
+  if (symbol == NULL)
+    return -1;
+  else
+    return symbol->value;
 }

--- a/symbols.h
+++ b/symbols.h
@@ -1,5 +1,5 @@
-/* Copyright (C) 2018 Lars Brinkhoff <lars@nocrew.org>
-   Copyright (C) 2018, 2019 Adam Sampson <ats@offog.org>
+/* Copyright (C) 2018, 2020 Lars Brinkhoff <lars@nocrew.org>
+   Copyright (C) 2018, 2019, 2020 Adam Sampson <ats@offog.org>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -47,6 +47,8 @@ struct symbol
 };
 
 extern void add_symbol (const char *name, word_t value, int flags);
+extern const struct symbol *get_symbol_by_name (const char *name);
 extern const struct symbol *get_symbol_by_value (word_t value, int hint);
+extern word_t get_symbol_value (const char *name);
 
 #endif


### PR DESCRIPTION
A save file contains the parts of the interpreter's memory other than the interpreter code itself, including impure low memory and pages of pure Muddle code/data that are stored or not according to Muddle's page map.

The locations of the variables necessary to do this vary between Muddle versions and platforms, so the loader populates the symbol table based on the version number in the file. It also includes some register and variable definitions that are useful for understanding compiled Muddle code.

The loader is based on [this Python script](https://github.com/atsampson/its-tests/blob/master/tools/explain-muddle).

While doing this, I spotted that the DMP info code wasn't adding to the symbol table, so I've fixed that too.