### PR TITLE
Add word format for octal numbers, one word per line.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ CFLAGS = -g -W -Wall
 FILES =  sblk-file.o pdump-file.o dmp-file.o raw-file.o shr-file.o \
 	 mdl-file.o
 
-WORDS =  bin-word.o its-word.o x-word.o dta-word.o aa-word.o pt-word.o core-word.o tape-word.o cadr-word.o
+WORDS =  aa-word.o bin-word.o cadr-word.o core-word.o dta-word.o its-word.o \
+	 oct-word.o pt-word.o tape-word.o x-word.o
 
 OBJS =	pdp10-opc.o info.o dis.o symbols.o \
 	timing.o timing_ka10.o timing_ki10.o memory.o weenix.o
@@ -176,6 +177,7 @@ its2bin.o: its2bin.c dis.h
 its2x.o: its2x.c dis.h
 main.o: main.c dis.h opcode/pdp10.h memory.h
 memory.o: memory.c memory.h dis.h
+oct-word.o: oct-word.c dis.h
 pdp10-opc.o: pdp10-opc.c opcode/pdp10.h
 pdump.o: pdump.c dis.h memory.h
 saildart.o: saildart.c dis.h

--- a/dis.h
+++ b/dis.h
@@ -69,6 +69,7 @@ extern struct word_format cadr_word_format;
 extern struct word_format core_word_format;
 extern struct word_format dta_word_format;
 extern struct word_format its_word_format;
+extern struct word_format oct_word_format;
 extern struct word_format pt_word_format;
 extern struct word_format tape_word_format;
 extern struct word_format tape7_word_format;

--- a/oct-word.c
+++ b/oct-word.c
@@ -1,0 +1,69 @@
+/* Copyright (C) 2021 Lars Brinkhoff <lars@nocrew.org>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/* This understands words as octal numbers, one word per line. */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "dis.h"
+
+static word_t
+get_oct_word (FILE *f)
+{
+  static char line[100];
+  word_t word;
+  char *p;
+  int i;
+
+  for (;;)
+    {
+    next:
+      p = fgets (line, sizeof line, f);
+      if (p == NULL)
+        return -1;
+
+      while (strchr (" \t", *p))
+        p++;
+
+      word = 0;
+      for (i = 0; i < 12; i++)
+        {
+          if (!strchr ("01234567", *p))
+            goto next;
+          word <<= 3;
+          word += *p++ - '0';
+        }
+
+      if (strchr ("01234567", *p))
+        goto next;
+
+      return word;
+    }
+}
+
+static void
+write_oct_word (FILE *f, word_t word)
+{
+  fprintf (f, "%012llo\n", word);
+}
+
+struct word_format oct_word_format = {
+  "oct",
+  get_oct_word,
+  NULL,
+  write_oct_word,
+  NULL
+};

--- a/word.c
+++ b/word.c
@@ -28,6 +28,7 @@ static struct word_format *word_formats[] = {
   &core_word_format,
   &dta_word_format,
   &its_word_format,
+  &oct_word_format,
   &pt_word_format,
   &tape_word_format,
   &tape7_word_format,


### PR DESCRIPTION
In particular, this is useful for binary files from saildart.org.