### PR TITLE
Don't write user messages to stdout when extracting DART tape.

### DIFF
--- a/dart.c
+++ b/dart.c
@@ -35,7 +35,6 @@
 #define MAX 10240
 static word_t block[MAX];
 static int extract = 0;
-static int verbose = 0;
 
 static FILE *list;
 static FILE *info;
@@ -808,6 +807,7 @@ main (int argc, char **argv)
   void (*process_tape) (FILE *) = NULL;
   char *tape_name = NULL, *mode;
   char *directory = NULL;
+  int verbose = 0;
   FILE *f;
   int opt;
 

--- a/dart.c
+++ b/dart.c
@@ -790,7 +790,6 @@ write_tape (FILE *f)
   if (f == NULL)
     f = stdout;
 
-  dart = 5;
   tape_frames = 0;
   write_header (f, HEAD);
   for (i = 0; i < file_argc; i++)
@@ -886,7 +885,6 @@ main (int argc, char **argv)
 	case '2':
 	case '3':
 	  iover = opt - '0';
-	  dart = iover + 3;
 	  break;
 	case '7':
 	  input_word_format = &tape7_word_format;
@@ -944,6 +942,10 @@ main (int argc, char **argv)
 	       directory, strerror (errno));
       exit (1);
     }
+
+  /* DART version is roughly three higher than IOVER.  This is a
+     reasonable approximation. */
+  dart = iover + 3;
 
   file_argc = argc - optind;
   file_argv = argv + optind;

--- a/dart.c
+++ b/dart.c
@@ -815,6 +815,11 @@ main (int argc, char **argv)
   input_word_format = &tape7_word_format;
   output_word_format = &aa_word_format;
 
+  /* If you ask for a file listing with -t or -xv, it's considered the
+     output data and written to stdout.  Overriden by -c, see below. */
+  list = stdout;
+  info = debug = stderr;
+
   while ((opt = getopt (argc, argv, "ctvx123789f:W:C:")) != -1)
     {
       switch (opt)
@@ -857,6 +862,9 @@ main (int argc, char **argv)
 	      exit (1);
 	    }
 	  process_tape = write_tape;
+	  /* Do not write file listing to stdout since it may mix with
+	     tape data written to stdout. */
+	  list = stderr;
 	  mode = "wb";
 	  break;
 	case '1':
@@ -901,7 +909,6 @@ main (int argc, char **argv)
   if (process_tape == NULL)
     usage (argv[0]);
 
-  list = info = debug = stdout;
   if (verbose < 1)
     list = fopen ("/dev/null", "w");
   if (verbose < 2)


### PR DESCRIPTION
Because the tape image may be written to stdout.