### PR TITLE
FASL file format.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 CFLAGS = -g -W -Wall
 
 FILES =  sblk-file.o pdump-file.o dmp-file.o raw-file.o shr-file.o \
-	 mdl-file.o rim10-file.o
+	 mdl-file.o rim10-file.o fasl-file.o
 
 WORDS =  aa-word.o bin-word.o cadr-word.o core-word.o data8-word.o \
 	 dta-word.o its-word.o oct-word.o pt-word.o sail-word.o tape-word.o \

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Most tools support these PDP-10 36-bit word encodings:
 - Core dump 9-track tape format.
 - DATA8, one 36-bit word stored right alinged per little endian 64-bit word.
 - DTA, DECtape image.
+- FASL, Maclisp compiled fast load files.
 - ITS evacuate format.
 - Octal digits.
 - Paper tape image.

--- a/dis.h
+++ b/dis.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013, 2021 Lars Brinkhoff <lars@nocrew.org>
+/* Copyright (C) 2013, 2021-2022 Lars Brinkhoff <lars@nocrew.org>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -64,6 +64,7 @@ enum {
 extern struct file_format *input_file_format;
 extern struct file_format *output_file_format;
 extern struct file_format dmp_file_format;
+extern struct file_format fasl_file_format;
 extern struct file_format mdl_file_format;
 extern struct file_format pdump_file_format;
 extern struct file_format raw_file_format;

--- a/fasl-file.c
+++ b/fasl-file.c
@@ -1,0 +1,360 @@
+/* Copyright (C) 2022 Lars Brinkhoff <lars@nocrew.org>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dis.h"
+#include "memory.h"
+#include "symbols.h"
+
+#define NFASL 0124641635413LL  /* *FASL+ */
+#define OFASL 0124641635412LL  /* *FASL* */
+
+static int atom_index = 1;
+static char *atomtable[1000];
+static int type[1000];
+
+static int address; //Current absolute address to load into.
+static int offset;  //Relocation offset.
+
+static int
+fasl_magic (word_t word)
+{
+  return word == NFASL || word == OFASL;
+}
+
+static void
+read_atomtable (FILE *f, word_t header)
+{
+  char string[100];
+  int length;
+  word_t data;
+
+  //fprintf (stderr, "Atomtable type %llo:  ", (header >> 33) & 7);
+  type[atom_index] = (header >> 33) & 7;
+  switch (type[atom_index])
+    {
+    case 0: //Atom.
+      char *p = string;
+      length = header & 0777777;
+      while (length--)
+        {
+          data = get_word (f);
+          *p++ = (data >> 29) & 0177;
+          *p++ = (data >> 22) & 0177;
+          *p++ = (data >> 15) & 0177;
+          *p++ = (data >>  8) & 0177;
+          *p++ = (data >>  1) & 0177;
+        }
+      //fprintf (stderr, "Atom index %d pname \"%s\"\n", atom_index, string);
+      atomtable[atom_index++] = strdup (string);
+      string[5] = 0;
+      break;
+    case 1: //Fixnum.
+      data = get_word (f);
+      //fprintf (stderr, "Atom index %d fixnum %012llo\n", atom_index, data);
+      snprintf (string, sizeof string, "Fixnum %012llo", data);
+      atomtable[atom_index++] = strdup (string);
+      break;
+    case 2: //Flonum.
+      data = get_word (f);
+      //fprintf (stderr, "Atom index %d flonum %012llo\n", atom_index, data);
+      snprintf (string, sizeof string, "Flonum %012llo", data);
+      atomtable[atom_index++] = strdup (string);
+      break;
+    case 3: //Bignum.
+      length = header & 0777777;
+      while (length--)
+        data = get_word (f);
+      //fprintf (stderr, "Atom index %d bignum\n", atom_index);
+      atomtable[atom_index++] = strdup ("Bignum");
+      break;
+    case 4: //Double-precision number.
+      data = get_word (f);
+      data = get_word (f);
+      //fprintf (stderr, "Atom index %d double\n", atom_index);
+      atomtable[atom_index++] = strdup ("Double");
+      break;
+    case 5: //Complex number.
+      data = get_word (f);
+      data = get_word (f);
+      //fprintf (stderr, "Atom index %d complex\n", atom_index);
+      atomtable[atom_index++] = strdup ("Complex");
+      break;
+    case 6: //Duplex number.
+      data = get_word (f);
+      data = get_word (f);
+      data = get_word (f);
+      data = get_word (f);
+      //fprintf (stderr, "Atom index %d duplex\n", atom_index);
+      atomtable[atom_index++] = strdup ("Duplex");
+      break;
+    case 7: //Unused.
+      fprintf (stderr, "Bad value.\n");
+      exit (1);
+      break;
+    }
+
+}
+
+static void 
+load (struct pdp10_memory *memory, word_t data)
+{
+  word_t *p = malloc (sizeof data);
+  *p = data;
+  add_memory (memory, address++, 1, p);
+}
+
+static word_t
+relocate (word_t word, word_t offset, word_t mask)
+{
+  return (word & ~mask) | ((word + offset) & mask);
+}
+
+static void
+patch (struct pdp10_memory *memory, word_t data, word_t mask, const char *x)
+{
+  word_t word = get_word_at (memory, address - 1);
+  word = relocate (word, data, mask);
+  set_word_at (memory, address - 1 , word);
+  (void)x;
+  //fprintf (stderr, "%06o/ %012llo (%s)\n", address - 1, word, x);
+}
+
+static void 
+discard (struct pdp10_memory *memory, word_t data)
+{
+  (void)memory;
+  (void)data;
+  //fprintf (stderr, "Discard.\n");
+}
+
+static void
+read_sexp (FILE *f, word_t data, struct pdp10_memory *memory,
+           void (*end) (struct pdp10_memory *, word_t))
+{
+  int items = 0;
+
+  for (;;)
+    {
+      switch ((data >> 33) & 7)
+        {
+        case 0:
+          //fprintf (stderr, "Push atom %lld onto stack.\n", data & 0777777);
+          items++;
+          break;
+        case 2:
+          //fprintf (stderr, "Make a list ended by atom popped off list.\n");
+          items--;
+          // Fall through.
+        case 1:
+          //fprintf (stderr, "Pop %lld items off stack and make a list.\n", data & 0777777);
+          items -= data & 0777777;
+          items++;
+          break;
+        case 3:
+          //fprintf (stderr, "Evaluate top item on stack.\n");
+          break;
+        case 4:
+          //fprintf (stderr, "Make a hunk from %lld stack items.\n", data & 0777777);
+          items -= data & 0777777;
+          items++;
+          break;
+        case 5:
+        case 6:
+          fprintf (stderr, "Bad value.\n");
+          exit (1);
+          break;
+        case 7:
+          if (items != 1)
+            //fprintf (stderr, "Stack items now: %d\n", items);
+          switch (data >> 18)
+            {
+            case 0777777:
+              end (memory, data);
+              break;              
+            case 0777776:
+              //fprintf (stderr, "Load into atomtable index %d.\n", atom_index);
+              atomtable[atom_index++] = "(list)";
+              break;              
+            default:
+              fprintf (stderr, "Bad value.\n");
+              break;              
+            }
+          if (end == load)
+            {
+              data = get_word (f);
+              //fprintf (stderr, "Hash key: %012llo.\n", data);
+            }
+          return;
+        }
+      data = get_word (f);
+    }
+}
+
+static int
+read_block (FILE *f, struct pdp10_memory *memory)
+{
+  char symbol[7];
+  char string[100];
+  word_t relocations;
+  word_t data, value;
+  int i;
+
+  relocations = get_word (f);
+  for (i = 0; i < 9; i++)
+    {
+      data = get_word (f);
+      switch ((relocations >> 32) & 017)
+        {
+        case 000:
+          load (memory, data);
+          //fprintf (stderr, "%06o/ %012llo\n", address - 1, data);
+          break;
+        case 001:
+          load (memory, data);
+          data += offset;
+          patch (memory, data, 0777777LL, "RELOCATABLE");
+          break;
+        case 002:
+          snprintf (string, sizeof string, "SPECIAL %s", atomtable[data & 0777777]);
+          data &= 0777777000000LL;
+          data |= 0 & 0777777;
+          load (memory, data);
+          break;
+        case 003:
+          snprintf (string, sizeof string, "SMASHABLE CALL %s", atomtable[data & 0777777]);
+          load (memory, data);
+          //fprintf (stderr, "%06o/ %012llo (%s)\n", address - 1, data, string);
+          break;
+        case 004:
+          snprintf (string, sizeof string, "QUOTED ATOM %s", atomtable[data & 0777777]);
+          data = (data & 0777777000000LL) | 0;
+          load (memory, data);
+          //fprintf (stderr, "%06o/ %012llo (%s)\n", address - 1, data, string);
+          break;
+        case 005:
+          //fprintf (stderr, "Type 05, QUOTED LIST\n");
+          read_sexp (f, data, memory, load);
+          break;
+        case 006:
+          snprintf (string, sizeof string, "GLOBALSYM index %llu", data & 0777777);
+          data = 0;
+          patch (memory, data, 0777777LL, string);
+          break;
+        case 007:
+          if (data == 0777777777777LL)
+            {
+              patch (memory, (word_t)offset << 18, 0777777000000LL, "LH");
+            }
+          else
+            {
+              squoze_to_ascii (data & 037777777777LL, symbol);
+              snprintf (string, sizeof string, "DDT SYMBOL %s", symbol);
+              data = 0;
+              patch (memory, data, 0777777LL, string);
+            }
+          break;
+        case 010:
+          snprintf (string, sizeof string, "ARRAY REFERENCE %s", atomtable[data & 0777777]);
+          data = 0;
+          patch (memory, data, 0777777LL, string);
+          break;
+        case 011:
+          /* Unused. */
+          fprintf (stderr, "Bad value.\n");
+          exit (1);
+          break;
+        case 012:
+          read_atomtable (f, data);
+          break;
+        case 013:
+          /*fprintf (stderr, "DEFUN %s %s",
+            atomtable[data >> 18], atomtable[data & 0777777]);*/
+          value = get_word (f);
+          /*fprintf (stderr, ", address %06llo args %06llo\n",
+            value & 0777777, value >> 18);*/
+          value = relocate (value & 0777777, offset, 0777777);
+          add_symbol (atomtable[data >> 18], value, SYMBOL_HALFKILLED);
+          break;
+        case 014:
+          address = relocate (data & 0777777, offset, 0777777);
+          break;
+        case 015:
+          squoze_to_ascii (data & 037777777777LL, symbol);
+          if (data & 0400000000000LL)
+            value = get_word (f);
+          else
+            value = address;
+          fprintf (stderr, "PUTDDTSYM %s = %012llo", symbol, value);
+          if (data & 0100000000000LL)
+            value = relocate (value, offset, 0777777);
+          if (data & 0200000000000LL)
+            value = relocate (value, (word_t)offset << 18, 0777777000000LL);
+          //fprintf (stderr, "PUTDDTSYM %s = %012llo\n", symbol, value);
+          fprintf (stderr, " -> %012llo\n", value);
+          add_symbol (symbol, value, SYMBOL_HALFKILLED);
+          break;
+        case 016:
+          //fprintf (stderr, "Type 05, EVAL MUNGEABLE\n");
+          read_sexp (f, data, memory, discard);
+          break;
+        case 017:
+          if (!fasl_magic (data))
+            fprintf (stderr, "Not a valid FASL file.\n");
+          return 0;
+        }
+      relocations <<= 4;
+    }
+
+  return 1;
+}
+
+static void
+read_fasl (FILE *f, struct pdp10_memory *memory, int cpu_model)
+{
+  char version[7];
+  word_t word;
+
+  (void)cpu_model;
+
+  fprintf (output_file, "FASL format\n");
+
+  word = get_word (f);
+  if (!fasl_magic (word))
+    {
+      fprintf (stderr, "Not a valid FASL file.\n");
+      exit (1);
+    }
+
+  word = get_word (f);
+  sixbit_to_ascii (word, version);
+  fprintf (output_file, "  Lisp version: %s\n", version);
+
+  // The conventional starting address.
+  offset = 0100;
+
+  address = offset;
+  while (read_block (f, memory))
+    ;
+}
+
+struct file_format fasl_file_format = {
+  "fasl",
+  read_fasl,
+  NULL
+};

--- a/file.c
+++ b/file.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013 Lars Brinkhoff <lars@nocrew.org>
+/* Copyright (C) 2013, 2022 Lars Brinkhoff <lars@nocrew.org>
    Copyright (C) 2020 Adam Sampson <ats@offog.org>
 
     This program is free software: you can redistribute it and/or modify
@@ -24,6 +24,7 @@ struct file_format *output_file_format = NULL;
 
 static struct file_format *file_formats[] = {
   &dmp_file_format,
+  &fasl_file_format,
   &mdl_file_format,
   &pdump_file_format,
   &raw_file_format,


### PR DESCRIPTION
From L; FASLOA 263

```
;;; FORMAT OF FASL FILES:
;;;
;;; THE "NEW" FASLOAD SCHEME (AS OF 1/31/73) USES A NEW FORMAT FOR
;;; ITS FILES. A FASL FILE CONSISTS OF TWO HEADER WORDS, FOLLOWED BY
;;; A SERIES OF FASL BLOCKS; THE TWO HEADER WORDS ARE BOTH SIXBIT,
;;; THE FIRST BEING "*FASL+" (FOR HISTORICAL REASONS, "*FASL* IS
;;; ALSO ACCEPTED) AND THE SECOND THE CONTENTS OF LOCATION LDFNM2 IN
;;; THE LISP WHICH ASSEMBLED THE FILE (A VERSION NUMBER IN SIXBIT).
;;; EACH FASL BLOCK CONSISTS OF A WORD OF NINE FOUR-BIT RELOCATION
;;; BYTES, FOLLOWED BY NINE PIECES OF FASL DATA.  THE LENGTH OF EACH
;;; DATA ITEM IS DEPENDENT ON THE RELOCATION TYPE; THUS FASLBLOCKS
;;; ARE OF VARYING LENGTH.  THE LAST BLOCK MAY HAVE FEWER THAN NINE
;;; DATA ITEMS.  THE RELOCATION TYPES AND THE FORMATS OF THE
;;; ASSOCIATED DATA ITEMS ARE AS FOLLOWS:
;;;
;;;     TYPE 0  ABSOLUTE
;;; ONE ABSOLUTE WORD TO BE LOADED.
;;;
;;;     TYPE 1  RELOCATABLE
;;; ONE WORD, THE RIGHT HALF OF WHICH IS RELOCATABLE; I.E. AT LOAD
;;; TIME THE LOAD OFFSET IS TO BE ADDED TO THE RIGHT HALF.
;;;
;;;     TYPE 2  SPECIAL
;;; A WORD TO BE LOADED, WHOSE RIGHT HALF CONTAINS THE INDEX OF AN
;;; ATOM (HOPEFULLY OF TYPE PNAME) THE ADDRESS OF THE VALUE CELL OF
;;; WHICH IS TO REPLACE THE RIGHT HALF OF THE LOADED WORD. (IF NO
;;; VALUE CELL EXISTS, ONE IS TO BE CREATED.)
;;;
;;;     TYPE 3  SMASHABLE CALL
;;; SIMILAR TO TYPE 4 (Q.V.) EXCEPT THAT THE INSTRUCTION IS ONE OF
;;; THE SERIES OF CALL UUOS WHICH MAY BE "SMASHED" FOR PURIFICATION
;;; PURPOSES. AT PRESENT THESE UUOS ARE: CALL, JCALL, NCALL, NJCALL.
;;;
;;;     TYPE 4  QUOTED ATOM
;;; ONE WORD TO BE LOADED WHOSE RIGHT HALF CONTAINS THE INDEX OF AN
;;; ATOM WHOSE ADDRESS IS TO REPLACE THE RIGHT HALF OF THE WORD
;;; LOADED.
;;;
;;;     TYPE 5  QUOTED LIST
;;; A SERIES OF WORDS REPRESENTING AN S-EXPRESSION TO BE CONSTRUCTED
;;; BY THE LOADER. THE FORMAT OF THESE WORDS IS BEST EXPLAINED BY
;;; THE ALGORITHM USED TO CONTRUCT THE S-EXPRESSION: THE LOADER
;;; EXAMINES BITS 4.7-4.9 OF SUCCESSIVELY READ WORDS, AND DISPATCHES
;;; ON THEM:
;;; 0   THE ATOM WHOSE INDEX IS IN THE RIGHT HALF OF THE WORD
;;;     IS PUSHED ONTO A STACK.
;;; 1   THE LOADER POPS AS MANY ITEMS OFF THE STACK AS
;;;     SPECIFIED BY THE NUMBER IN THE RIGHT HALF OF THE WORD
;;;     AND MAKES A LIST OF THEM, SO THAT THE LAST ITEM POPPED
;;;     BECOMES THE FIRST ITEM OF THE LIST; THIS LIST IS THEN
;;;     PUSHED ONTO THE STACK.
;;; 2   THE LOADER POPS ONE ITEM OFF THE STACK AND PROCEEDS AS
;;;     FOR 1, EXCEPT THAT THE ITEM FIRST POPPED IS USED TO
;;;     END THE LIST INSTEAD IF NIL. (THIS ALLOWS FOR DOTTED
;;;     PAIRS.)
;;; 3   THE TOP ITEM ON THE STACK IS EVALUATED AND STORED BACK
;;;     ON THE TOP OF THE STACK.
;;; 4   THE RIGHT HALF OR THE WORD SPECIFIES THE LENGTH OF A
;;;     HUNK TO BE MADE BY TAKING THAT MANY ITEMS FROM THE TOP
;;;     OF THE STACK;  THIS HUNK IS THEN PUSHED BACK.
;;; 5   UNUSED.
;;; 6   UNUSED.
;;; 7   THE LEFT HALF OF THE WORD SHOULD BE -1 OR -2,
;;;     INDICATING THE SECOND LAST WORD OF THE DATA; IF -1,
;;;     THE RIGHT HALF OF THIS WORD AND THE ADDRESS OF (WHAT
;;;     SHOULD BE) THE SINGLE ITEM ON THE STACK (WHICH IS
;;;     POPPED OFF) ARE MADE RESPECTIVELY INTO THE LEFT AND
;;;     RIGHT HALVES OF A WORD TO BE LOADED INTO BINARY
;;;     PROGRAM SPACE; IF -2, THE S-EXPRESSION IS PLACED INTO
;;;     THE NEXT SLOT OF THE ATOMTABLE (SEE TYPE 12).  THE ONE
;;;     WORD REMAINING IS THE HASH KEY OF THE S-EXPRESSION AS
;;;     COMPUTED BY SXHASH; THIS IS USED BY THE LOADER TO SAVE
;;;     GCPRO SOME WORK.
;;;
;;;     TYPE 6  GLOBALSYM
;;; ONE WORD; THE RIGHT HALF IS AN INDEX INTO THE TABLE LSYMS IN
;;; LISP. THE INDICATED VALUE IS RETRIEVED, NEGATED IF BIT 4.9 OF
;;; THE DATA WORD IS 1, AND ADDED TO THE RIGHT HALF OF THE LAST
;;; WORD LOADED INTO BINARY PROGRAM SPACE.  THIS ALLOWS LAP CODE
;;; TO REFER TO SELECTED LOCATIONS INTERNAL TO LISP WITHOUT
;;; GETTING SYMBOLS FROM DDT.
;;;
;;;     TYPE 7  GETDDTSYM
;;; IF THE FIRST WORD IS -1, THEN THE LOAD OFFSET IF ADDED INTO
;;; THE LEFT HALF OF THE WORD MOST RECENTLY LOADED INTO BINARY
;;; PROGRAM SPACE (THIS IS HOW LEFT HALF RELOCATION IS
;;; ACCOMPLISHED).  OTHERWISE, THE FIRST WORD CONTAINS IN BITS
;;; 1.1-4.5 A SYMBOL IN SQUOZE CODE. THE LOADER GETS THE VALUE OF
;;; THIS SYMBOL FROM DDT IF POSSIBLE, NEGATES IT IF BIT 4.9 IS 1,
;;; THEN ADDS THE RESULT TO THE FIELD OF THE LAST WORD LOADED AS
;;; SPECIFIED BY BITS 4.6-4.7:
;;;     3 = ENTIRE WORD
;;;     2 = AC FIELD ONLY
;;;     1 = RIGHT HALF ONLY
;;;     0 = ENTIRE WORD, BUT SWAP HALVES OF VALUE BEFORE ADDING.
;;; THESE FOUR FIELDS CORRESPOND TO OPCODE, AC, ADDRESS, AND INDEX
;;; FIELDS RESPECTIVELY IN A LAP INSTRUCTION.  IF BIT 4.8 IS A 1,
;;; THEN ANOTHER WORD FOLLOWS, CONTAINING THE VALUE OF THE SYMBOL
;;; AS OBTAINED FROM DDT AT ASSEMBLE TIME. IF THE VERSION NUMBER
;;; OF THAT LISP (AS DETERMINED FROM THE SECOND FILE HEADER WORD)
;;; IS THE SAME AS THAT OF THE LISP BEING LOADED INTO, THEN THIS
;;; VALUE IS USED AND DDT IS NOT CONSULTED AT LOAD TIME; THIS IS
;;; FOR SPEED. IF THE VERSION NUMBERS ARE DIFFERENT, THEN DDT IS
;;; CONSULTED.
;;;
;;;     TYPE 10 ARRAY REFERENCE
;;; ONE WORD TO BE LOADED, WHOSE RIGHT HALF CONTAINS THE ATOMINDEX
;;; OF AN ATOMIC SYMBOL. IF THE SYMBOL HAS AN ARRAY PROPERTY, IT
;;; IS FETCHED; OTHERWISE ONE IS CREATED. THE RIGHT HALF OF THE
;;; WORD TO BE LOADED IS REPLACED WITH THE ADDRESS OF THE SECOND
;;; WORD OF THE ARRAY POINTER (I.E. OF THE TTSAR).  IN THIS WAY
;;; ACCESSES TO ARRAYS CAN BE OPEN-CODED.
;;;
;;;     TYPE 11 UNUSED
;;;
;;;     TYPE 12 ATOMTABLE INFO
;;; A HEADER WORD, POSSIBLY FOLLOWED BY OTHERS, DEPENDING ON BITS
;;; 4.7-4.9:
;;; 0   THE RIGHT HALF IS THE NUMBER OF WORDS FOLLOWING, WHICH
;;;     CONSTITUTE THE PNAME OF A PNAME-TYPE ATOM, IN THE
;;;     ORDER OF THEIR APPEARANCE ON A PROPERTY LIST. THE ATOM
;;;     IS INTERNED.
;;; 1   THE ONE WORD FOLLOWING IS THE VALUE OF A FIXNUM TO BE
;;;     CREATED.
;;; 2   THE FOLLOWING WORD IS THE VALUE OF A FLONUM.
;;; 3   THE RIGHT HALF IS THE NUMBER OF FIXNUM COMPONENTS OF A
;;;     BIGNUM FOLLOWING, MOST SIGNIFICANT WORD FIRST.  BIT 3.1
;;;     IS THE SIGN OF THE BIGNUM.
;;; 4   THE FOLLOWING TWO WORDS ARE A DOUBLE-PRECISION NUMBER.
;;; 5   THE FOLLOWING TWO WORDS ARE A COMPLEX NUMBER.
;;; 6   THE FOLLOWING FOUR WORDS ARE A DUPLEX NUMBER.
;;; 7   UNUSED.
;;; THE ATOM THUS CREATED IS ASSIGNED A PLACE IN THE ATOMTABLE
;;; MAINTAINED BY THE LOADER (AS AN ARRAY) USING CONSECUTIVE
;;; LOCATIONS; FROM THAT POINT ON OTHER DATA ITEMS REFERRING TO
;;; THAT ITEM CAN DO SO BY THE INDEX OF THE ATOM IN THIS TABLE.
;;; SEE ALSO TYPES 5 AND 16, WHICH ALSO MAKE ENTRIES IN THE
;;; ATOMTABLE.
;;;
;;;     TYPE 13 ENTRY INFO
;;; TWO WORDS. THE LEFT HALF OF THE FIRST WORD IS THE ATOMINDEX
;;; OF THE NAME OF THE FUNCTION BEING DEFINED; THE RIGHT HALF
;;; THAT OF THE SUBR TYPE (THE PROPERTY UNDER WHICH TO CREATE THE
;;; ENTRY POINT, E.G. SUBR OR FSUBR).  THE RIGHT HALF OF THE
;;; SECOND WORD IS THE LOCATION OF THE ENTRY POINT AS A
;;; RELOCATABLE POINTER: THE LOAD OFFSET MUST BE ADDED TO IT. THE
;;; LEFT HALF OF THE SECOND WORD CONTAINS THE ARGS PROPERTY, IN
;;; INTERNAL ARGS PROPERTY FORMAT, AS SPECIFIED IN THE ORIGINAL
;;; LAP CODE BY THE ARGS CONSTRUCT.
;;;
;;;     TYPE 14 LOC
;;; THE WORD IS A RELOCATABLE QUANTITY SPECIFYING WHERE TO
;;; CONTINUE LOADING.  IT IS NOT PERMITTED TO LOC BELOW THE
;;; ORIGIN OF THE ASSEMBLY. IF THE LOC IS TO A LOCATION HIGHER
;;; THAN ANY YET LOADED INTO, THEN FASLOAD ZEROS OUT ALL WORDS
;;; ABOVE THAT HIGHEST LOCATION UP TO THE LOCATION SPECIFIED.
;;; FASLOAD KEEPS TRACK OF THE HIGHEST LOCATION EVER LOADED INTO;
;;; THIS VALUE PLUS ONE BECOMES THE VALUE OF BPORG AT THE END OF
;;; ASSEMBLY, REGARDLESS OF THE STATE OF THE LOCATION POINTER
;;; WHEN LOADING TERMINATES.  THIS TYPE IS NEVER USED BY LAP
;;; CODE, BUT ONLY BY MIDAS .FASL CODE.
;;;
;;;     TYPE 15 PUTDDTSYM
;;; FIRST WORD, THE SYMBOL IN SQUOZE CODE.  IF BIT 4.9=0, THE
;;; SYMBOL IS DEFINED TO DDT IF POSSIBLE WITH THE ADDRESS OF THE
;;; WORD OF BINARY PROGRAM SPACE ABOUT TO BE LOADED INTO AS ITS
;;; VALUE.  IF BIT 4.9=1, THE VALUE IS GOBBLED FROM THE FOLLOWING
;;; WORD. BIT 4.8 (OF THE WORD CONTAINING THE SQUOZE) MEANS
;;; RELOCATE THE LEFT HALF OF THE VALUE BY THE LOAD OFFSET, AND
;;; BIT 4.7 LIKEWISE FOR THE RIGHT HALF.  WHETHER OR NOT THE
;;; SYMBOL ACTUALLY GETS PUT IN DDT'S SYMBOL TABLE IS A FUNCTION
;;; OF THREE CONDITIONS: FIRST, THAT THERE IS A DDT WITH A SYMBOL
;;; TABLE; SECOND, THE VALUE OF THE LISP VARIABLE "SYMBOLS";
;;; THIRD, BIT 4.6 OF THE FIRST PUTDDTSYM WORD. THE FIRST
;;; CONDITION OF COURSE MUST BE SATISFIED. IF SO, THEN THE SYMBOL
;;; IS PUT IN THE SYMBOL TABLE ONLY IF SYMBOLS HAS A NON-NIL
;;; VALUE. FURTHERMORE, IF THAT VALUE IS THE ATOM SYMBOLS ITSELF,
;;; THEN THE SYMBOL IS PUT ONLY IF BIT 4.6 IS ON (INDICATING A
;;; "GLOBAL" SYMBOL).
;;;
;;;     TYPE 16 EVAL MUNGEABLE
;;; A SERIES OF WORDS SIMILAR TO THOSE FOR TYPE 5, BUT WITH NO
;;; FOLLOWING HASH KEY. AN S-EXPRESSION IS CONSTRUCTED AND
;;; EVALUATED. THIS IS USED FOR THE SO-CALLED "MUNGEABLES" IN A
;;; FILE OF LAP CODE.  IF THE LEFT HALF OF THE LAST WORD IS -1,
;;; THE VALUE IS THROWN AWAY. IF IT IS -2, THE VALUE IS ENTERED
;;; IN THE ATOMTABLE.
;;;
;;;     TYPE 17 END OF BINARY
;;; ONE WORD, WHICH MUST BE "*FASL+" (OR "*FASL*") IN SIXBIT.
;;; THIS SHOULD BE THE LAST DATA WORD IN THE FILE. ANY RELOCATION
;;; BYTES LEFT OVER AFTER A TYPE 17 ARE IGNORED.  THIS SHOULD BE
;;; FOLLOWED EITHER BY END OF FILE OR A WORD FULL OF ^C'S.
```