### PR TITLE
Don't include accumulators in SBLK output.

### DIFF
--- a/sblk-file.c
+++ b/sblk-file.c
@@ -114,6 +114,8 @@ write_sblk_core (FILE *f, struct pdp10_memory *memory)
   for (i = 0; i < memory->areas; i++)
     {
       start = memory->area[i].start;
+      if (start < 020)
+	start = 020;
       length = memory->area[i].end - start;
       while (length > 0)
 	{


### PR DESCRIPTION
Traditionally accumulators aren't part of core image.  This is especially bad for RIM10 which runs from code in 0-17, so it's not good to overwrite that.