### PR TITLE
Have SBLK dump out the accumulators, but RIM10 not.

### DIFF
--- a/dis.h
+++ b/dis.h
@@ -126,7 +126,7 @@ extern void	read_raw_at (FILE *f, struct pdp10_memory *memory,
 			     int address);
 extern void	write_raw_at (FILE *f, struct pdp10_memory *memory,
 			      int address);
-extern void	write_sblk_core (FILE *f, struct pdp10_memory *memory);
+extern void	write_sblk_core (FILE *f, struct pdp10_memory *, int begin);
 extern void	write_sblk_symbols (FILE *f);
 extern void	write_dec_symbols (struct pdp10_memory *memory);
 extern void	sblk_info (FILE *f, word_t word0, int cpu_model);

--- a/rim10-file.c
+++ b/rim10-file.c
@@ -296,7 +296,7 @@ write_rim10 (FILE *f, struct pdp10_memory *memory)
   for (i = 0; i < sizeof midas_rim10 / sizeof midas_rim10[0]; i++)
     write_word (f, midas_rim10[i]);
 
-  write_sblk_core (f, memory);
+  write_sblk_core (f, memory, 020);
   write_word (f, start_instruction);
 }
 

--- a/sblk-file.c
+++ b/sblk-file.c
@@ -106,7 +106,7 @@ write_block (FILE *f, struct pdp10_memory *memory, int start, int end)
 }
 
 void
-write_sblk_core (FILE *f, struct pdp10_memory *memory)
+write_sblk_core (FILE *f, struct pdp10_memory *memory, int begin)
 {
   int start, length;
   int i, n;
@@ -114,8 +114,10 @@ write_sblk_core (FILE *f, struct pdp10_memory *memory)
   for (i = 0; i < memory->areas; i++)
     {
       start = memory->area[i].start;
-      if (start < 020)
-	start = 020;
+      if (memory->area[i].end <= begin)
+	continue;
+      if (start < begin)
+	start = begin;
       length = memory->area[i].end - start;
       while (length > 0)
 	{
@@ -170,7 +172,7 @@ static void
 write_sblk (FILE *f, struct pdp10_memory *memory)
 {
   write_word (f, JRST_1);
-  write_sblk_core (f, memory);
+  write_sblk_core (f, memory, 0);
   write_word (f, start_instruction);
   write_sblk_symbols (f);
   write_word (f, start_instruction);


### PR DESCRIPTION
Following up on #114.  On second thought, SBLK files do include the accumulator.  This reverts the behaviour for SBLK, but still have RIM10 start no lower than 20.