### PR TITLE
Fix some dumper problems.

### DIFF
--- a/dumper.c
+++ b/dumper.c
@@ -494,7 +494,7 @@ read_tape (FILE *f)
   word = get_word (f);
 
   word = read_tape_header (f, word);
-  for (;;)
+  while (word != -1)
     {
       word = read_record (f, word);
       switch ((01000000000000LL - block[4]) & 0777777777777LL)

--- a/libword/tape-word.c
+++ b/libword/tape-word.c
@@ -275,11 +275,15 @@ get_tape_word (FILE *f)
 	  words = get_tape_record (f, &buffer);
 	  if (words == 0)
 	    {
-	      /* Seen two tape marks.  Is this pysical or logical EOT? */
-	      words = get_tape_record (f, &buffer);
-	      if (feof (f))
-		/* End of input file means physical end of tape. */
-		return -1;
+	      while (words == 0)
+		{
+		  /* Seen two or more tape marks.  Is this pysical or
+		     logical EOT? */
+		  words = get_tape_record (f, &buffer);
+		  if (feof (f))
+		    /* End of input file means physical end of tape. */
+		    return -1;
+		}
 	      /* More data in input file; it was logical end of tape. */
 	      tape_bits = START_TAPE;
 	    }


### PR DESCRIPTION
1. Fix a bug when more two tape marks in a row are encoutered.
2. Write out extracted files.

CC @sandjo