### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ UTILS =	cat36 itsarc magdmp magfrm dskdmp dump \
 all: dis10 $(UTILS) check
 
 clean:
-	cd libword; make clean
+	cd libword; $(MAKE) clean
 	rm -f $(OBJS) libfiles.a
 	rm -f dis10 core
 	rm -f $(UTILS)
@@ -36,7 +36,7 @@ libfiles.a: file.o $(FILES)
 	ar -crs $@ $^
 
 $(LIBWORD):
-	cd libword && make
+	cd libword && $(MAKE)
 
 cat36: cat36.o $(LIBWORD)
 	$(CC) $(CFLAGS) $^ -o $@


### PR DESCRIPTION
Use $(MAKE) for recursive make invocation.   This respects the flags passed to the top level make as well as invoking the correct binary if the default is overridden on the command line.

The change fixes an ITS build failure on FreeBSD, which used `gmake MAKE=gmake EMULATOR=...` to recursively build everything using GNU make (gmake) instead of BSD make.

Tested on FreeBSD 13.1 using clang 13.0.0 (default compiler) and sanity checked on MacOS Monterey 12.6.2 using clang 14.0.0 (Xcode 14.1).  (MacOS uses GNU make by default.)