### PR TITLE
Clean macos debug symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 *.o
+*.dSYM
 acct
 cat36
 check

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ clean:
 	for f in $(UTILS); do rm -f $${f}.o; done
 	rm -f out/*
 	rm -f check
+	rm -rf *.dSYM
 
 dis10: main.o $(OBJS) libfiles.a $(LIBWORD)
 	$(CC) $(CFLAGS) $^ -o $@


### PR DESCRIPTION
A trivial patch that removes the debug symbol directories generated by a MacOS build.  These directories are now deleted by `make clean`, and .gitignore is updated so we are not pestered about them.

Checked on MacOS 12.6.2/Xcode 14.1.  Sanity checked on FreeBSD 13.1.  Both builds ran without error and behaved as expected.

Have a Happy New Year!
