### PR TITLE
Dump a subset of a core image.

### DIFF
--- a/csave-file.c
+++ b/csave-file.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022 Lars Brinkhoff <lars@nocrew.org>
+/* Copyright (C) 2022, 2026 Lars Brinkhoff <lars@nocrew.org>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -77,13 +77,22 @@ write_block (FILE *f, struct pdp10_memory *memory, int address, int length)
 static void
 write_core (FILE *f, struct pdp10_memory *memory)
 {
-  int start, length;
+  int start, end, length;
   int i, n;
 
   for (i = 0; i < memory->areas; i++)
     {
       start = memory->area[i].start;
-      length = memory->area[i].end - start;
+      end = memory->area[i].end;
+      if (start >= output_file_image_end_address)
+	continue;
+      if (end <= output_file_image_start_address)
+	continue;
+      if (start < output_file_image_start_address)
+	start = output_file_image_start_address;
+      if (end > output_file_image_end_address)
+	end = output_file_image_end_address;
+      length = end - start;
       while (length > 0)
 	{
 	  n = length > 512 ? 512 : length;

--- a/dis.h
+++ b/dis.h
@@ -38,6 +38,8 @@ struct pdp10_file;
 struct pdp10_memory;
 extern word_t start_instruction;
 extern FILE *output_file;
+extern int output_file_image_start_address;
+extern int output_file_image_end_address;
 
 struct file_format {
   const char *name;
@@ -82,7 +84,7 @@ extern void	read_raw_at (FILE *f, struct pdp10_memory *memory,
 			     int address);
 extern void	write_raw_at (FILE *f, struct pdp10_memory *memory,
 			      int address);
-extern void	write_sblk_core (FILE *f, struct pdp10_memory *, int begin);
+extern void	write_sblk_core (FILE *f, struct pdp10_memory *);
 extern void	write_sblk_symbols (FILE *f);
 extern void	write_dec_symbols (struct pdp10_memory *memory);
 extern void	sblk_info (FILE *f, word_t word0, int cpu_model);

--- a/dump.c
+++ b/dump.c
@@ -1,13 +1,41 @@
+/* Copyright (C) 2026 Lars Brinkhoff <lars@nocrew.org>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
 #include <stdio.h>
 #include <getopt.h>
 
 #include "dis.h"
 #include "memory.h"
 
+static int
+octal (const char *address)
+{
+  char *end;
+  unsigned long x = strtoul(address, &end, 8);
+  if (*end != 0)
+    {
+      fprintf (stderr, "Invalid address: %s\n", address);
+      exit (1);
+    }
+  return x;
+}
+
 static void
 usage (char **argv)
 {
-  fprintf (stderr, "Usage: %s [-F<input file format>] [-W<input word format>]\n"
+  fprintf (stderr, "Usage: %s [-F<input file format>] [-W<input word format>] [-s<start address>] [-e<end address>]\n"
                    "   [-O<output file format>] [-X<output word format>] [<files...>]\n\n", argv[0]);
   usage_file_format ();
   usage_word_format ();
@@ -24,7 +52,7 @@ main (int argc, char **argv)
   output_file = stderr;
   file = stdin;
 
-  while ((opt = getopt (argc, argv, "W:X:F:O:")) != -1)
+  while ((opt = getopt (argc, argv, "e:s:W:X:F:O:")) != -1)
     {
       switch (opt)
         {
@@ -43,6 +71,12 @@ main (int argc, char **argv)
         case 'O':
           if (parse_output_file_format (optarg))
             usage (argv);
+          break;
+        case 's':
+          output_file_image_start_address = octal (optarg);
+          break;
+        case 'e':
+          output_file_image_end_address = octal (optarg);
           break;
         default:
           usage (argv);

--- a/file.c
+++ b/file.c
@@ -21,6 +21,8 @@
 
 struct file_format *input_file_format = NULL;
 struct file_format *output_file_format = NULL;
+int output_file_image_start_address = 0;
+int output_file_image_end_address = 01000000;
 
 static struct file_format *file_formats[] = {
   &atari_file_format,

--- a/libword/word.c
+++ b/libword/word.c
@@ -106,19 +106,19 @@ seek_word (FILE *f, int position)
 {
   if (input_word_format->seek_word == NULL)
     {
-      input_word_format->rewind_word (f);
+      rewind_word (f);
       while (position-- > 0)
         get_word (f);
       return;
     }
 
-  input_word_format->rewind_word (f);
+  input_word_format->seek_word (f, position);
 }
 
 void
 by_five_octets (FILE *f, int position)
 {
-  input_word_format->rewind_word (f);
+  rewind_word (f);
   fseek (f, 5 * position, SEEK_SET);
 }
 

--- a/rim10-file.c
+++ b/rim10-file.c
@@ -296,7 +296,8 @@ write_rim10 (FILE *f, struct pdp10_memory *memory)
   for (i = 0; i < sizeof midas_rim10 / sizeof midas_rim10[0]; i++)
     write_word (f, midas_rim10[i]);
 
-  write_sblk_core (f, memory, 020);
+  output_file_image_start_address = 020;
+  write_sblk_core (f, memory);
   write_word (f, start_instruction);
 }
 

--- a/sblk-file.c
+++ b/sblk-file.c
@@ -106,19 +106,24 @@ write_block (FILE *f, struct pdp10_memory *memory, int start, int end)
 }
 
 void
-write_sblk_core (FILE *f, struct pdp10_memory *memory, int begin)
+write_sblk_core (FILE *f, struct pdp10_memory *memory)
 {
-  int start, length;
+  int start, end, length;
   int i, n;
 
   for (i = 0; i < memory->areas; i++)
     {
       start = memory->area[i].start;
-      if (memory->area[i].end <= begin)
+      end = memory->area[i].end;
+      if (start >= output_file_image_end_address)
 	continue;
-      if (start < begin)
-	start = begin;
-      length = memory->area[i].end - start;
+      if (end <= output_file_image_start_address)
+	continue;
+      if (start < output_file_image_start_address)
+	start = output_file_image_start_address;
+      if (end > output_file_image_end_address)
+	end = output_file_image_end_address;
+      length = end - start;
       while (length > 0)
 	{
 	  n = length > 512 ? 512 : length;
@@ -172,7 +177,7 @@ static void
 write_sblk (FILE *f, struct pdp10_memory *memory)
 {
   write_word (f, JRST_1);
-  write_sblk_core (f, memory, 0);
+  write_sblk_core (f, memory);
   write_word (f, start_instruction);
   write_sblk_symbols (f);
   write_word (f, start_instruction);

--- a/tendmp.c
+++ b/tendmp.c
@@ -452,11 +452,15 @@ read_file (FILE *f, int i)
 static int
 core_size (FILE *f)
 {
+  int core = 0;
+  int i;
   struct pdp10_memory memory;
   init_memory (&memory);
   input_file_format->read (f, &memory, 0);
   rewind_word (f);
-  return memory.area[memory.areas-1].end - memory.area[0].start;
+  for (i = 0; i < memory.areas; i++)
+    core += memory.area[i].end - memory.area[i].start;
+  return core;
 }
 
 static int
@@ -530,6 +534,11 @@ create_file (char *name)
   fn2 &= 0777777000000LL;
   if (csave_type (f, fn2))
     core = (core_size (f) + 1023) / 1024 - 1;
+  if (core > 077)
+    {
+      fprintf (stderr, "Warning: core size %dK exceeds maximum.\n", core);
+      core = 077;
+    }
   fn2 |= core << 12;
   i = allocate_dir (fn1, fn2);
   read_file (f, i);

--- a/tenex-file.c
+++ b/tenex-file.c
@@ -51,26 +51,27 @@ read_page (FILE *f, word_t *data)
 }
 
 static void
-get_page (FILE *f, int page, word_t *map, struct pdp10_memory *memory)
+get_page (FILE *f, word_t map, struct pdp10_memory *memory)
 {
-  word_t *data, *core = NULL;
-  int i, address;
+  word_t *data;
+  int page, address;
 
-  for (i = 0; i < PAGESIZE; i++)
-    {
-      if (RH (map[i]) == 0 || RH (map[i]) != page)
-	continue;
+  page = RH (map);
+  if (page == 0)
+    return;
 
-      address = (LH (map[i]) & 0777) * PAGESIZE;
-      data = malloc (PAGESIZE * sizeof (word_t));
-      if (core == NULL)
-	read_page (f, core = data);
-      else
-	memcpy (data, core, PAGESIZE * sizeof (word_t));
-      add_memory (memory, address, PAGESIZE, data);
-      if ((map[i] & PAGE_WRITE) == 0)
-	purify_memory (memory, address, PAGESIZE);
-    }
+  page--;
+  fprintf (stderr, "Seek to file page %o, position %lu\n",
+	   page, (long)(PAGESIZE * page));
+  seek_word (f, PAGESIZE * page);
+
+  address = (LH (map) & 0777) * PAGESIZE;
+  fprintf (stderr, "Virtual address %d\n", address);
+  data = malloc (PAGESIZE * sizeof (word_t));
+  read_page (f, data);
+  add_memory (memory, address, PAGESIZE, data);
+  if ((map & PAGE_WRITE) == 0)
+    purify_memory (memory, address, PAGESIZE);
 }
 
 static void
@@ -131,8 +132,13 @@ read_tenex (FILE *f, struct pdp10_memory *memory, int cpu_model)
   for (i = 0; i < 2 * PAGESIZE - count - 2; i++)
     get_word (f);
 
-  for (i = 2; i <= end; i++)
-    get_page (f, i, map, memory);
+  for (i = 0; i < count; i++) {
+    fprintf (stderr, "Get page %d %012llo\n", i, map[i]);
+    get_page (f, map[i], memory);
+  }
+
+  end++;
+  seek_word (f, PAGESIZE * end);
 
   while (!feof (f))
     {


### PR DESCRIPTION
Add to the `dump` tool -s and -e options for specifying the start and end addresses for a range of the core image to write.