### PR TITLE
List or extract files from a FAILSAFE tape.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dis10
 dskdmp
 dump
 dumper
+failsafe
 harscntopbm
 ipak
 itsarc

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ UTILS = acct calcomp cat36 classify-tape constantinople cross dart	\
         decdmp dskdmp dump dumper harscntopbm ipak itsarc kldcp		\
         klfedr linum macdmp macro-tapes magdmp magfrm mini-dumper	\
         od10 old-cpio palx plt scrmbl tape-dir tendmp tito tvpic	\
-        unscr
+        unscr failsafe
 
 all: dis10 $(UTILS) check
 
@@ -81,6 +81,9 @@ classify-tape: classify-tape.o tape-image.o
 
 acct: acct.o dec.o $(OBJS) $(LIBWORD)
 	$(CC) $(CFLAGS) $^ -o $@
+
+failsafe: tito
+	ln -f tito failsafe
 
 tito: tito.o $(OBJS) $(LIBWORD)
 	$(CC) $(CFLAGS) $^ -o $@

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ is elsewhere: http://github.com/larsbrinkhoff/mldev
 ## Tools for other PDP-10 systems.
 
 - List or extract files from a TITO tape (Tymshare TYMCOM-X).
+- List or extract files from a FAILSAFE tape (TOPS-10).
 - List, extract, or write files on a DART tape (SAIL WAITS).
 - Write files on a DUMPER tape (BBN TENEX, DEC TOPS-20).
 - Add or delete DEC-style text file line numbers.

--- a/dumper.c
+++ b/dumper.c
@@ -464,15 +464,21 @@ static void
 print_info (FILE *f, word_t *fdb)
 {
   int bits_per_byte, file_words;
+  int file_pages = right (fdb[011]);
 
   print_timestamp (f, fdb[5]);
-  fprintf (f, " %4d", right (fdb[011]));
+  fprintf (f, " %4d", file_pages);
   file_bytes = fdb[012];
   bits_per_byte = (fdb[011] >> 24) & 077;
-  word_bytes = bits_per_byte ? 36 / bits_per_byte : 0;
-  file_words = file_bytes / word_bytes;
-  file_octets = 5 * file_words;
-  file_octets += ((file_bytes % word_bytes) * bits_per_byte + 7) / 8;
+  if (file_bytes == 0)
+    file_octets = 5 * 512 * file_pages;
+  else {
+    word_bytes = bits_per_byte ? 36 / bits_per_byte : 0;
+    file_words = file_bytes / word_bytes;
+    file_octets = 5 * file_words;
+    file_octets += ((file_bytes % word_bytes) * bits_per_byte + 7) / 8;
+  }
+    file_octets = 5 * 512 * file_pages;
   fprintf (f, " %lld(%d)\n",
 	   file_bytes, bits_per_byte);
 }
@@ -516,7 +522,7 @@ read_data (void)
   int i;
   if (output == NULL)
     return;
-  for (i = 0; i < 512 && file_bytes >= 0; i++, file_bytes -= word_bytes)
+  for (i = 0; i < 512; i++)
     write_word (output, data[i]);
 }
 

--- a/dumper.c
+++ b/dumper.c
@@ -445,6 +445,11 @@ read_tape_header (FILE *f, word_t word)
     bfmsg = 0;
   else {
     bfmsg = data[1];
+    if (bfmsg > 500)
+      {
+	fprintf (stderr, "BFMSG is too large.");
+	exit (1);
+      }
     if (bfmsg == 0)
       bfmsg = format > 4 ? 10 : 3;
   }
@@ -737,7 +742,7 @@ write_tape (FILE *f)
   struct word_format *tmp = input_word_format;
   input_word_format = output_word_format;
   output_word_format = tmp;
-  int i, bfmsg;
+  int i, bfmsg = 0;
 
   if (f == NULL)
     f = stdout;
@@ -749,7 +754,6 @@ write_tape (FILE *f)
   if (format == 0)
     {
       record_number = 2;
-      bfmsg = 0;
     }
   else
     {

--- a/libword/tape-word.c
+++ b/libword/tape-word.c
@@ -115,12 +115,14 @@ int get_9track_record (FILE *f, word_t **buffer)
     return 0;
   else if (reclen & 0x80000000)
     {
+      return 0;
       tape_hook (reclen);
       return get_tape_record (f, buffer);
     }
 
   if (reclen % 5)
     {
+      return 0;
       fprintf (stderr, "Not a CORE DUMP tape image.\n"
 	       "reclen = %d\n", reclen);
       exit (1);

--- a/tito.c
+++ b/tito.c
@@ -33,6 +33,7 @@ static int density;
 static int extract = 0;
 static int verbose = 0;
 static int saveset = 1;
+static int tito_flag = -1;
 
 static FILE *list;
 static FILE *info;
@@ -338,7 +339,7 @@ process_file_header (FILE *f, word_t word)
     fprintf (stderr, "EXPECTED 0\n");
   fprintf (info, "Count for extended lookup: %d\n", right (block[2]));
 
-  if (first_file)
+  if (first_file && tito_flag)
     {
       fprintf (list, "System: ");
       print_ascii (list, block[073]);
@@ -353,12 +354,15 @@ process_file_header (FILE *f, word_t word)
   unix_time (&timestamp[0], t);
   unix_time (&timestamp[1], t);
 
-  sixbit_to_ascii (block[071], sixbit);
-  strcpy (directory, sixbit);
-  sixbit_to_ascii (block[072], sixbit);
-  strcat (directory, sixbit);
+  if (tito_flag)
+    {
+      sixbit_to_ascii (block[071], sixbit);
+      strcpy (directory, sixbit);
+      sixbit_to_ascii (block[072], sixbit);
+      strcat (directory, sixbit);
+    }
 
-  if (left (block[5]) == 0654644)
+  if (left (block[5]) == 0654644 && tito_flag)
     {
       fprintf (list, "   (UFD)          ");
       sixbit_to_ascii (block[031], sixbit);
@@ -372,13 +376,23 @@ process_file_header (FILE *f, word_t word)
     {
       sixbit_to_ascii (block[4], name);
       sixbit_to_ascii (block[5] & 0777777000000LL, ext);
-      strcat (directory, " ");
-      *strchr (directory, ' ') = ')';
-      fprintf (list, "   (%s %s.%s ", directory, name, ext);
+      if (tito_flag)
+	{
+	  strcat (directory, " ");
+	  *strchr (directory, ' ') = ')';
+	  fprintf (list, "   (%s %s.%s ", directory, name, ext);
+	}
+      else
+	{
+	  fprintf (list, "   %s.%s ", name, ext);
+	}
       ext[3] = '\0';
       print_timestamp (list, t);
       fprintf (list, "   [%o,%o]\n", left (block[3]), right (block[3]));
-      *strchr (directory, ')') = ' ';
+      if (!tito_flag)
+	sprintf (directory, "[%o,%o]", left (block[3]), right (block[3]));
+      if (tito_flag)
+	*strchr (directory, ')') = ' ';
     }
 
   switch (right (block[1]))
@@ -401,8 +415,11 @@ process_file_header (FILE *f, word_t word)
   word = get_word (f);
   if (extract && left (block[5]) != 0654644)
     {
+      int offset = tito_flag ? 0101 : 043;
       open_file (directory, name, ext);
-      write_data (block + 0101, size - 0101);
+      if (!tito_flag)
+	size++;
+      write_data (block + offset, size - offset);
       if (!data_record (word))
 	close_file (block[size - 1]);
     }
@@ -479,7 +496,7 @@ process_saveset (FILE *f)
 static void
 usage (const char *x)
 {
-  fprintf (stderr, "Usage: %s -t|-x [-v] [-7] [-Wformat] [-f file]\n", x);
+  fprintf (stderr, "Usage: %s [-T|-F] -t|-x [-v] [-7] [-Wformat] [-f file]\n", x);
   usage_word_format ();
   exit (1);
 }
@@ -496,7 +513,7 @@ main (int argc, char **argv)
   if (argc == 1)
     usage (argv[0]);
 
-  while ((opt = getopt (argc, argv, "tvx7f:W:")) != -1)
+  while ((opt = getopt (argc, argv, "tvx7f:W:TF")) != -1)
     {
       switch (opt)
 	{
@@ -530,6 +547,12 @@ main (int argc, char **argv)
 	  if (parse_output_word_format (optarg))
 	    usage (argv[0]);
 	  break;
+	case 'T':
+	  tito_flag = 1;
+	  break;
+	case 'F':
+	  tito_flag = 0;
+	  break;
 	default:
 	  usage (argv[0]);
 	}
@@ -543,6 +566,25 @@ main (int argc, char **argv)
     list = info = fopen ("/dev/null", "w");
   else if (verbose == 1)
     info = fopen ("/dev/null", "w");
+
+  if (tito_flag == -1)
+    {
+      /* No -F or -T given; figure out if this is failsafe or tito. */
+      const char *p = strrchr (argv[0], '/');
+      if (p == NULL)
+        p = argv[0];
+      else
+	p++;
+      if (p[0] == 't')
+	tito_flag = 1;
+      else if (p[0] == 'f')
+	tito_flag = 0;
+      else
+	{
+	  fprintf (stderr, "Input format not selected; use -T or -F.\n");
+	  exit (1);
+	}
+    }
 
   for (;;)
     process_saveset (f);

--- a/tito.c
+++ b/tito.c
@@ -46,14 +46,16 @@ static int first_file;
 static int
 february (int year)
 {
-  if (year < 1964 || year > 1999)
+  if (year < 1964)
     {
       fprintf (stderr, "Anachronistic timestamp: year %d\n", year);
-      exit (1);
     }
 
-  /* This is good for the range 1964-1999, which is all we care about. */
-  if ((year % 4) == 0)
+  if ((year % 400) == 0)
+    return 29;
+  else if ((year % 100) == 0)
+    return 28;
+  else if ((year % 4) == 0)
     return 29;
   else
     return 28;
@@ -67,11 +69,8 @@ compute_date (word_t word, int *year, int *month, int *day)
   *month = 0;
 
   mdays[1] = february (*year);
-  for (;;)
+  while (*day >= mdays[*month])
     {
-      if (*day < mdays[*month])
-	return;
-
       *day -= mdays[*month];
       (*month)++;
       if (*month == 12)


### PR DESCRIPTION
There already is a program for Tymshare TITO tapes, and as it turns out, this is just an extended FAILSAFE format.  So a new flag was added to select between FAILSAFE or TITO.

This works with these two tapes:  
https://pdp-10.trailing-edge.com/tapes/AP-D481A-SB_1978.tap.bz2  
https://bitsavers.org/bits/DEC/pdp10/magtape/decus/DECUS_LIB_FAILSAFE_TAPE_2_3-16-73.tap.gz  